### PR TITLE
Manually destructure tuple of locations passed to map function

### DIFF
--- a/Turf/Turf.swift
+++ b/Turf/Turf.swift
@@ -186,8 +186,7 @@ public struct Turf {
         let sliced = polyline(along: line, from: start, to: end)
         
         // Zip together the starts and ends of each segment, then map those pairs of coordinates to the distances between them, then take the sum.
-        let distance = zip(sliced.prefix(upTo: sliced.count - 1), sliced.suffix(from: 1)).map(-).reduce(0, +)
-        
+        let distance = zip(sliced.prefix(upTo: sliced.count - 1), sliced.suffix(from: 1)).map { args in args.0 - args.1 }.reduce(0, +)
         return distance
     }
     


### PR DESCRIPTION
As noted in https://bugs.swift.org/browse/SR-4738?focusedCommentId=24311&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-24311, destructuring tuple arguments in map `was special-case behavior that only worked for a single tuple argument but that is going away in -swift-version 4.`

This proposal makes `class Turf.distance(along:from:to:)` compatible with Swift 4 and also works in Swift 3.2.

cc @frederoni @friedbunny 