### PR TITLE
Rewrite installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,64 @@
-# Turf-swift 
+# Turf for Swift 
 
-📱[![](https://www.bitrise.io/app/49f5bcca71bf6c8d/status.svg?token=SzGBTkEtxsbuAnbcF9MTog&branch=master)](https://www.bitrise.io/app/49f5bcca71bf6c8d)
-🖥💻[![](https://www.bitrise.io/app/b72273651db53613/status.svg?token=ODv2UnyAHoOxV8APATEBFw&branch=master)](https://www.bitrise.io/app/b72273651db53613)
-📺[![](https://www.bitrise.io/app/0b037542c2395ffb/status.svg?token=yOtMqbu-5bj8grB1Jmoefg)](https://www.bitrise.io/app/0b037542c2395ffb)
-⌚️[![](https://www.bitrise.io/app/0d4d611f02295183/status.svg?token=NiLB_E_0IvYYqV4Mj973TQ)](https://www.bitrise.io/app/0d4d611f02295183)
+📱[![](https://www.bitrise.io/app/49f5bcca71bf6c8d/status.svg?token=SzGBTkEtxsbuAnbcF9MTog&branch=master)](https://www.bitrise.io/app/49f5bcca71bf6c8d) &nbsp;&nbsp;&nbsp;
+🖥💻[![](https://www.bitrise.io/app/b72273651db53613/status.svg?token=ODv2UnyAHoOxV8APATEBFw&branch=master)](https://www.bitrise.io/app/b72273651db53613) &nbsp;&nbsp;&nbsp;
+📺[![](https://www.bitrise.io/app/0b037542c2395ffb/status.svg?token=yOtMqbu-5bj8grB1Jmoefg)](https://www.bitrise.io/app/0b037542c2395ffb) &nbsp;&nbsp;&nbsp;
+⌚️[![](https://www.bitrise.io/app/0d4d611f02295183/status.svg?token=NiLB_E_0IvYYqV4Mj973TQ)](https://www.bitrise.io/app/0d4d611f02295183)  
+[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage) &nbsp;&nbsp;&nbsp;
+[![CocoaPods](https://img.shields.io/cocoapods/v/Turf.svg)](http://cocoadocs.org/docsets/Turf/) &nbsp;&nbsp;&nbsp;
+[![SPM compatible](https://img.shields.io/badge/SPM-compatible-4BC51D.svg?style=flat)](https://swift.org/package-manager/) &nbsp;&nbsp;&nbsp;
 
 A [spatial analysis](http://en.wikipedia.org/wiki/Spatial_analysis) library written in Swift for native iOS, macOS, tvOS, and watchOS applications, ported from [Turf.js](https://github.com/Turfjs/turf/).
 
-The Turf-swift API is **experimental** and is subject to change. Please use with caution and open issues for any problems you see or missing features that should be added.
+Turf for Swift is **experimental** and its public API is subject to change. Please use with care and open issues for any problems you see or missing features that should be added.
 
-### Installation
+## Requirements
 
-Although there has not yet been a beta release of this library yet, you can still experiment with it in your application by using CocoaPods to install it. Edit your Podfile to include:
+Turf is written in Swift 4, requires Xcode 9 to build, and deploys back to iOS 8.
 
+## Installation
+
+Although a stable release of this library is not yet available, prereleases are available for installation using any of the popular Swift dependency managers.
+
+### CocoaPods
+
+To install Turf using [CocoaPods](https://cocoapods.org/):
+
+1. Specify the following dependency in your Podfile:
+   ```rb
+   pod 'Turf', '~> 0.0.4'
+   ```
+1. Run `pod repo update` if you haven’t lately.
+1. Run `pod install` and open the resulting Xcode workspace.
+1. Add `import Turf` to any Swift file in your application target.
+
+### Carthage
+
+To install Turf using [Carthage](https://github.com/Carthage/Carthage/):
+
+1. Add the following dependency to your Cartfile:
+   ```
+   github "mapbox/turf-swift" ~> 0.0.4
+   ```
+1. Run `carthage bootstrap`.
+1. Follow the rest of [Carthage’s integration instructions](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application). Your application target’s Embedded Frameworks should include Turf.framework.
+1. Add `import Turf` to any Swift file in your application target.
+
+### Swift Package Manager
+
+To install Turf using the [Swift Package Manager](https://swift.org/package-manager/), add the following package to the `dependencies` in your Package.swift file:
+
+```swift
+.Package(url: "https://github.com/mapbox/turf-swift.git", .upToNextMinor(from: "0.0.4"))
 ```
-pod 'Turf-swift', '~> 0.0.4'
-```
 
-Alternatively, you can clone this repo and drag and drop Turf.swift and CoreLocation.swift into your project in Xcode.
+Then `import Turf` in any Swift file in your module.
 
-### Available functionality
+### Manual installation
+
+For one-off experiments, clone this repository, then drag and drop [Turf.swift and CoreLocation.swift](https://github.com/mapbox/turf-swift/tree/master/Sources/Turf/) into your project in Xcode.
+
+## Available functionality
 
 This work-in-progress port of [Turf.js](https://github.com/Turfjs/turf/) contains the following functionality:
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,20 @@
 [![CocoaPods](https://img.shields.io/cocoapods/v/Turf.svg)](http://cocoadocs.org/docsets/Turf/) &nbsp;&nbsp;&nbsp;
 [![SPM compatible](https://img.shields.io/badge/SPM-compatible-4BC51D.svg?style=flat)](https://swift.org/package-manager/) &nbsp;&nbsp;&nbsp;
 
-A [spatial analysis](http://en.wikipedia.org/wiki/Spatial_analysis) library written in Swift for native iOS, macOS, tvOS, and watchOS applications, ported from [Turf.js](https://github.com/Turfjs/turf/).
+A [spatial analysis](http://en.wikipedia.org/wiki/Spatial_analysis) library written in Swift for native iOS, macOS, tvOS, watchOS, and Linux applications, ported from [Turf.js](https://github.com/Turfjs/turf/).
 
 Turf for Swift is **experimental** and its public API is subject to change. Please use with care and open issues for any problems you see or missing features that should be added.
 
 ## Requirements
 
-Turf is written in Swift 4, requires Xcode 9 to build, and deploys back to iOS 8.
+Turf is written in Swift 4. It requires Xcode 9.x and supports the following minimum deployment targets:
+
+* iOS 8.0 and above
+* macOS 10.10.0 (Yosemite) and above
+* tvOS 9.0 and above
+* watchOS 2.0 and above
+
+Alternatively, you can incorporate Turf into a command line tool without Xcode on any platform that [Swift](https://swift.org/download/) supports, including Linux.
 
 ## Installation
 


### PR DESCRIPTION
Rewrote the “Installation” section of the readme, adding sections for Carthage and SPM. Also, the name of the pod is `Turf`, not `Turf-swift`.

/cc @frederoni @captainbarbosa