### PR TITLE
Yosemite, not Cheetah

### DIFF
--- a/Turf.podspec
+++ b/Turf.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   # ――― Platform Specifics ――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.ios.deployment_target = "8.0"
-  s.osx.deployment_target = "10.0"
+  s.osx.deployment_target = "10.10"
   s.tvos.deployment_target = "9.0"
   s.watchos.deployment_target = "2.0"
 


### PR DESCRIPTION
Deploying backwards to Mac OS X 10.0 is probably not a great use of our time.

![](https://venturebeat.com/wp-content/uploads/2013/03/os_x_ad.png)

/cc @friedbunny