### PR TITLE
Set up continuous integration on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+os:
+  - linux
+language: generic
+sudo: required
+dist: trusty
+env:
+  - SWIFT_VERSION=4.0.3
+install:
+  - eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
+script:
+  - swift build


### PR DESCRIPTION
Closes #35 

Compiles turf-swift on Ubuntu trusty using Swift 4.0.3

Unfortunately, no tests are running yet because [SPM doesn't support resources](https://bugs.swift.org/browse/SR-2866).

@1ec5 👀 