### PR TITLE
Remove swift 4.1 warning

### DIFF
--- a/Sources/Turf/CoreLocation.swift
+++ b/Sources/Turf/CoreLocation.swift
@@ -54,6 +54,7 @@ extension CLLocationCoordinate2D: Equatable {
     
     /// Instantiates a CLLocationCoordinate from a RadianCoordinate2D
     public init(_ radianCoordinate: RadianCoordinate2D) {
+        self.init()
         latitude = radianCoordinate.latitude.toDegrees()
         longitude = radianCoordinate.longitude.toDegrees()
     }

--- a/Sources/Turf/CoreLocation.swift
+++ b/Sources/Turf/CoreLocation.swift
@@ -54,9 +54,7 @@ extension CLLocationCoordinate2D: Equatable {
     
     /// Instantiates a CLLocationCoordinate from a RadianCoordinate2D
     public init(_ radianCoordinate: RadianCoordinate2D) {
-        self.init()
-        latitude = radianCoordinate.latitude.toDegrees()
-        longitude = radianCoordinate.longitude.toDegrees()
+        self.init(latitude: radianCoordinate.latitude.toDegrees(), longitude: radianCoordinate.longitude.toDegrees())
     }
     
     public static func ==(lhs: CLLocationCoordinate2D, rhs: CLLocationCoordinate2D) -> Bool {


### PR DESCRIPTION
Removes this warning:
![image](https://user-images.githubusercontent.com/1058624/38324332-d6992860-37f4-11e8-9268-e90c9cf710b4.png)

/cc @mapbox/navigation-ios @captainbarbosa 