### PR TITLE
Add support for xcode 10, only import swift files

### DIFF
--- a/Turf.podspec
+++ b/Turf.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
 
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
-  s.source_files = "Sources/**/*"
+  s.source_files = "Sources/**/*.swift"
 
   # ――― Project Settings ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 

--- a/Turf.podspec
+++ b/Turf.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
 
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
-  s.source_files = "Sources/**/*.swift"
+  s.source_files = "Sources/**/*{.swift,.h}"
 
   # ――― Project Settings ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 


### PR DESCRIPTION
If this is left wide open, all and any file type get copied over when using cocoapods. If used in conjunction with xcode 10, it fails to compile and complains it's copied twice.

Should this also include .h files?

/cc @1ec5 @frederoni 