### PR TITLE
Encode GeoJSON feature type

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,4 +100,26 @@ let geojson = try! GeoJSON.parse(data: data)
 
 // Decode known GeoJSON type
 let geojson = try! GeoJSON.parse(data: data, as: FeatureCollection.self)
+
+// Initialize a PointFeature and encode as GeoJSON
+let coordinate = CLLocationCoordinate2D(latitude: 0, longitude: 1)
+let point = Point(coordinate)
+let pointFeature = PointFeature(point)
+let data = try! JSONEncoder().encode(pointFeature)
+let json = String(data: data, encoding: .utf8)
+print(json)
+
+/*
+{
+  "type": "Feature",
+  "geometry": {
+    "type": "Point",
+    "coordinates": [
+      1,
+      0
+    ]
+  }
+}
+*/
+
 ```

--- a/Sources/Turf/Codable.swift
+++ b/Sources/Turf/Codable.swift
@@ -23,6 +23,10 @@ extension Bool: JSONType {
 public struct AnyJSONType: JSONType {
     public let jsonValue: Any
     
+    public init(_ value: Any) {
+        self.jsonValue = value
+    }
+    
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         

--- a/Sources/Turf/FeatureCollection.swift
+++ b/Sources/Turf/FeatureCollection.swift
@@ -2,11 +2,13 @@ import Foundation
 
 
 public struct FeatureCollection: GeoJSONObject {
+    public var type: FeatureType = .featureCollection
     public var identifier: FeatureIdentifier?
     public var features: Array<FeatureVariant> = []
     public var properties: [String : AnyJSONType]?
     
     private enum CodingKeys: String, CodingKey {
+        case type
         case properties
         case features
     }
@@ -23,6 +25,7 @@ public struct FeatureCollection: GeoJSONObject {
     
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(type, forKey: .type)
         try container.encode(features, forKey: .features)
         try container.encode(properties, forKey: .properties)
     }

--- a/Sources/Turf/GeoJSON.swift
+++ b/Sources/Turf/GeoJSON.swift
@@ -3,12 +3,32 @@ import Foundation
 import CoreLocation
 #endif
 
+public enum FeatureType: String {
+    case feature = "Feature"
+    case featureCollection = "FeatureCollection"
+}
+
+extension FeatureType: Codable {
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.rawValue)
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self = try container.decode(FeatureType.self)
+    }
+}
+
 public protocol GeoJSONObject: Codable {
+    var type: FeatureType { get }
     var identifier: FeatureIdentifier? { get set }
     var properties: [String: AnyJSONType]? { get set }
 }
 
 enum GeoJSONCodingKeys: String, CodingKey {
+    case type
     case properties
     case geometry
     case identifier = "id"

--- a/Sources/Turf/LineString.swift
+++ b/Sources/Turf/LineString.swift
@@ -17,6 +17,7 @@ public struct LineString: Codable, Equatable {
 }
 
 public struct LineStringFeature: GeoJSONObject {
+    public var type: FeatureType = .feature
     public var identifier: FeatureIdentifier?
     public var geometry: LineString!
     public var properties: [String : AnyJSONType]?
@@ -30,6 +31,7 @@ public struct LineStringFeature: GeoJSONObject {
     
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: GeoJSONCodingKeys.self)
+        try container.encode(type, forKey: .type)
         try container.encode(geometry, forKey: .geometry)
         try container.encode(properties, forKey: .properties)
         try container.encodeIfPresent(identifier, forKey: .identifier)

--- a/Sources/Turf/MultiLineString.swift
+++ b/Sources/Turf/MultiLineString.swift
@@ -13,6 +13,7 @@ public struct MultiLineString: Codable, Equatable {
 }
 
 public struct MultiLineStringFeature: GeoJSONObject {
+    public var type: FeatureType = .feature
     public var identifier: FeatureIdentifier?
     public var geometry: MultiLineString!
     public var properties: [String : AnyJSONType]?
@@ -26,6 +27,7 @@ public struct MultiLineStringFeature: GeoJSONObject {
     
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: GeoJSONCodingKeys.self)
+        try container.encode(type, forKey: .type)
         try container.encode(geometry, forKey: .geometry)
         try container.encode(properties, forKey: .properties)
         try container.encodeIfPresent(identifier, forKey: .identifier)

--- a/Sources/Turf/MultiPoint.swift
+++ b/Sources/Turf/MultiPoint.swift
@@ -13,6 +13,7 @@ public struct MultiPoint: Codable, Equatable {
 }
 
 public struct MultiPointFeature: GeoJSONObject {
+    public var type: FeatureType = .feature
     public var identifier: FeatureIdentifier?
     public var geometry: MultiPoint!
     public var properties: [String : AnyJSONType]?
@@ -26,6 +27,7 @@ public struct MultiPointFeature: GeoJSONObject {
     
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: GeoJSONCodingKeys.self)
+        try container.encode(type, forKey: .type)
         try container.encode(geometry, forKey: .geometry)
         try container.encode(properties, forKey: .properties)
         try container.encodeIfPresent(identifier, forKey: .identifier)

--- a/Sources/Turf/MultiPoint.swift
+++ b/Sources/Turf/MultiPoint.swift
@@ -10,13 +10,21 @@ import CoreLocation
 public struct MultiPoint: Codable, Equatable {
     var type: String = GeometryType.MultiPoint.rawValue
     public var coordinates: [CLLocationCoordinate2D]
+    
+    public init(_ coordinates: [CLLocationCoordinate2D]) {
+        self.coordinates = coordinates
+    }
 }
 
 public struct MultiPointFeature: GeoJSONObject {
     public var type: FeatureType = .feature
     public var identifier: FeatureIdentifier?
-    public var geometry: MultiPoint!
+    public var geometry: MultiPoint
     public var properties: [String : AnyJSONType]?
+    
+    public init(_ geometry: MultiPoint) {
+        self.geometry = geometry
+    }
     
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: GeoJSONCodingKeys.self)

--- a/Sources/Turf/MultiPolygon.swift
+++ b/Sources/Turf/MultiPolygon.swift
@@ -10,6 +10,10 @@ import CoreLocation
 public struct MultiPolygon: Codable, Equatable {
     var type: String = GeometryType.MultiPolygon.rawValue
     public var coordinates: [[[CLLocationCoordinate2D]]]
+    
+    public init(_ coordinates: [[[CLLocationCoordinate2D]]]) {
+        self.coordinates = coordinates
+    }
 }
 
 public struct MultiPolygonFeature: GeoJSONObject {
@@ -17,6 +21,10 @@ public struct MultiPolygonFeature: GeoJSONObject {
     public var identifier: FeatureIdentifier?
     public var geometry: MultiPolygon
     public var properties: [String : AnyJSONType]?
+    
+    public init(_ geometry: MultiPolygon) {
+        self.geometry = geometry
+    }
     
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: GeoJSONCodingKeys.self)

--- a/Sources/Turf/MultiPolygon.swift
+++ b/Sources/Turf/MultiPolygon.swift
@@ -8,13 +8,14 @@ import CoreLocation
  A `MultiLineString` geometry. The coordinates property represents a `[LineString]`.
  */
 public struct MultiPolygon: Codable, Equatable {
-    var type: String = GeometryType.MultiLineString.rawValue
+    var type: String = GeometryType.MultiPolygon.rawValue
     public var coordinates: [[[CLLocationCoordinate2D]]]
 }
 
 public struct MultiPolygonFeature: GeoJSONObject {
+    public var type: FeatureType = .feature
     public var identifier: FeatureIdentifier?
-    public var geometry: MultiPolygon!
+    public var geometry: MultiPolygon
     public var properties: [String : AnyJSONType]?
     
     public init(from decoder: Decoder) throws {
@@ -26,6 +27,7 @@ public struct MultiPolygonFeature: GeoJSONObject {
     
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: GeoJSONCodingKeys.self)
+        try container.encode(type, forKey: .type)
         try container.encode(geometry, forKey: .geometry)
         try container.encode(properties, forKey: .properties)
         try container.encodeIfPresent(identifier, forKey: .identifier)

--- a/Sources/Turf/Point.swift
+++ b/Sources/Turf/Point.swift
@@ -10,6 +10,10 @@ import CoreLocation
 public struct Point: Codable, Equatable {
     var type: String = GeometryType.Point.rawValue
     public var coordinates: CLLocationCoordinate2D
+    
+    public init(_ coordinates: CLLocationCoordinate2D) {
+        self.coordinates = coordinates
+    }
 }
 
 public struct PointFeature: GeoJSONObject {
@@ -17,6 +21,10 @@ public struct PointFeature: GeoJSONObject {
     public var identifier: FeatureIdentifier?
     public var geometry: Point
     public var properties: [String : AnyJSONType]?
+    
+    public init(_ geometry: Point) {
+        self.geometry = geometry
+    }
     
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: GeoJSONCodingKeys.self)

--- a/Sources/Turf/Point.swift
+++ b/Sources/Turf/Point.swift
@@ -13,8 +13,9 @@ public struct Point: Codable, Equatable {
 }
 
 public struct PointFeature: GeoJSONObject {
+    public var type: FeatureType = .feature
     public var identifier: FeatureIdentifier?
-    public var geometry: Point!
+    public var geometry: Point
     public var properties: [String : AnyJSONType]?
     
     public init(from decoder: Decoder) throws {
@@ -26,6 +27,7 @@ public struct PointFeature: GeoJSONObject {
     
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: GeoJSONCodingKeys.self)
+        try container.encode(type, forKey: .type)
         try container.encode(geometry, forKey: .geometry)
         try container.encode(properties, forKey: .properties)
         try container.encodeIfPresent(identifier, forKey: .identifier)

--- a/Sources/Turf/Polygon.swift
+++ b/Sources/Turf/Polygon.swift
@@ -11,7 +11,7 @@ public struct Polygon: Codable, Equatable {
     var type: String = GeometryType.Polygon.rawValue
     public var coordinates: [[CLLocationCoordinate2D]]
     
-    init(coordinates: [[CLLocationCoordinate2D]]) {
+    public init(_ coordinates: [[CLLocationCoordinate2D]]) {
         self.coordinates = coordinates
     }
     
@@ -29,6 +29,10 @@ public struct PolygonFeature: GeoJSONObject {
     public var identifier: FeatureIdentifier?
     public var geometry: Polygon
     public var properties: [String : AnyJSONType]?
+    
+    public init(_ geometry: Polygon) {
+        self.geometry = geometry
+    }
     
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: GeoJSONCodingKeys.self)

--- a/Sources/Turf/Polygon.swift
+++ b/Sources/Turf/Polygon.swift
@@ -25,8 +25,9 @@ public struct Polygon: Codable, Equatable {
 }
 
 public struct PolygonFeature: GeoJSONObject {
+    public var type: FeatureType = .feature
     public var identifier: FeatureIdentifier?
-    public var geometry: Polygon!
+    public var geometry: Polygon
     public var properties: [String : AnyJSONType]?
     
     public init(from decoder: Decoder) throws {
@@ -38,6 +39,7 @@ public struct PolygonFeature: GeoJSONObject {
     
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: GeoJSONCodingKeys.self)
+        try container.encode(type, forKey: .type)
         try container.encode(geometry, forKey: .geometry)
         try container.encode(properties, forKey: .properties)
         try container.encodeIfPresent(identifier, forKey: .identifier)

--- a/Tests/TurfTests/FeatureCollectionTests.swift
+++ b/Tests/TurfTests/FeatureCollectionTests.swift
@@ -68,7 +68,7 @@ class FeatureCollectionTests: XCTestCase {
         let data = try! Fixture.geojsonData(from: "featurecollection")!
         
         measure {
-            for _ in 0...1000 {
+            for _ in 0...100 {
                 _ = try! GeoJSON.parse(FeatureCollection.self, from: data)
             }
         }
@@ -79,7 +79,7 @@ class FeatureCollectionTests: XCTestCase {
         let decoded = try! GeoJSON.parse(FeatureCollection.self, from: data)
         
         measure {
-            for _ in 0...1000 {
+            for _ in 0...100 {
                 _ = try! JSONEncoder().encode(decoded)
             }
         }
@@ -89,7 +89,7 @@ class FeatureCollectionTests: XCTestCase {
         let data = try! Fixture.geojsonData(from: "featurecollection")!
         
         measure {
-            for _ in 0...1000 {
+            for _ in 0...100 {
                 let decoded = try! GeoJSON.parse(FeatureCollection.self, from: data)
                 _ = try! JSONEncoder().encode(decoded)
             }

--- a/Tests/TurfTests/MultiPointTests.swift
+++ b/Tests/TurfTests/MultiPointTests.swift
@@ -12,12 +12,12 @@ class MultiPointTests: XCTestCase {
         
         let firstCoordinate = CLLocationCoordinate2D(latitude: 26.194876675795218, longitude: 14.765625)
         let lastCoordinate = CLLocationCoordinate2D(latitude: 24.926294766395593, longitude: 17.75390625)
-        XCTAssert(geojson.geometry?.coordinates.first == firstCoordinate)
-        XCTAssert(geojson.geometry?.coordinates.last == lastCoordinate)
+        XCTAssert(geojson.geometry.coordinates.first == firstCoordinate)
+        XCTAssert(geojson.geometry.coordinates.last == lastCoordinate)
         
         let encodedData = try! JSONEncoder().encode(geojson)
         let decoded = try! GeoJSON.parse(MultiPointFeature.self, from: encodedData)
-        XCTAssert(decoded.geometry?.coordinates.first == firstCoordinate)
-        XCTAssert(decoded.geometry?.coordinates.last == lastCoordinate)
+        XCTAssert(decoded.geometry.coordinates.first == firstCoordinate)
+        XCTAssert(decoded.geometry.coordinates.last == lastCoordinate)
     }
 }

--- a/Tests/TurfTests/MultiPolygonTests.swift
+++ b/Tests/TurfTests/MultiPolygonTests.swift
@@ -15,12 +15,61 @@ class MultiPolygonTests: XCTestCase {
         
         let firstCoordinate = CLLocationCoordinate2D(latitude: 0, longitude: 0)
         let lastCoordinate = CLLocationCoordinate2D(latitude: 11, longitude: 11)
-        XCTAssert(geojson.geometry?.coordinates.first?.first?.first == firstCoordinate)
-        XCTAssert(geojson.geometry?.coordinates.last?.last?.last == lastCoordinate)
+        XCTAssert(geojson.geometry.coordinates.first?.first?.first == firstCoordinate)
+        XCTAssert(geojson.geometry.coordinates.last?.last?.last == lastCoordinate)
         
         let encodedData = try! JSONEncoder().encode(geojson)
         let decoded = try! GeoJSON.parse(MultiPolygonFeature.self, from: encodedData)
-        XCTAssert(decoded.geometry?.coordinates.first?.first?.first == firstCoordinate)
-        XCTAssert(decoded.geometry?.coordinates.last?.last?.last == lastCoordinate)
+        XCTAssert(decoded.geometry.coordinates.first?.first?.first == firstCoordinate)
+        XCTAssert(decoded.geometry.coordinates.last?.last?.last == lastCoordinate)
+    }
+    
+    func testBuildMultiPolygonFeature() {
+        let coordinates =
+        [
+            [
+                [
+                    CLLocationCoordinate2D(latitude: 0, longitude: 0),
+                    CLLocationCoordinate2D(latitude: 0, longitude: 5),
+                    CLLocationCoordinate2D(latitude: 0, longitude: 5),
+                    CLLocationCoordinate2D(latitude: 0, longitude: 10),
+                    CLLocationCoordinate2D(latitude: 10, longitude: 10),
+                    CLLocationCoordinate2D(latitude: 10, longitude: 0),
+                    CLLocationCoordinate2D(latitude: 5, longitude: 0),
+                    CLLocationCoordinate2D(latitude: 0, longitude: 0),
+                ],[
+                    CLLocationCoordinate2D(latitude: 5, longitude: 1),
+                    CLLocationCoordinate2D(latitude: 7, longitude: 1),
+                    CLLocationCoordinate2D(latitude: 8.5, longitude: 1),
+                    CLLocationCoordinate2D(latitude: 8.5, longitude: 4.5),
+                    CLLocationCoordinate2D(latitude: 7, longitude: 4.5),
+                    CLLocationCoordinate2D(latitude: 5, longitude: 4.5),
+                    CLLocationCoordinate2D(latitude: 5, longitude: 1)
+                ]
+            ],[
+                [
+                    CLLocationCoordinate2D(latitude: 11, longitude: 11),
+                    CLLocationCoordinate2D(latitude: 11.5, longitude: 11.5),
+                    CLLocationCoordinate2D(latitude: 12, longitude: 12),
+                    CLLocationCoordinate2D(latitude: 11, longitude: 12),
+                    CLLocationCoordinate2D(latitude: 11, longitude: 11.5),
+                    CLLocationCoordinate2D(latitude: 11, longitude: 11),
+                    CLLocationCoordinate2D(latitude: 11, longitude: 11)
+                ]
+            ]
+        ]
+        
+        let multiPolygon = MultiPolygon(coordinates)
+        var multiPolygonFeature = MultiPolygonFeature(multiPolygon)
+        multiPolygonFeature.identifier = FeatureIdentifier.string("uniqueIdentifier")
+        multiPolygonFeature.properties = ["some": AnyJSONType("var")]
+
+        let encodedData = try! JSONEncoder().encode(multiPolygonFeature)
+        let decodedCustomMultiPolygon = try! GeoJSON.parse(MultiPolygonFeature.self, from: encodedData)
+        
+        let data = try! Fixture.geojsonData(from: "multipolygon")!
+        let bundledMultiPolygon = try! GeoJSON.parse(MultiPolygonFeature.self, from: data)
+        
+        XCTAssertEqual(decodedCustomMultiPolygon.geometry.coordinates, bundledMultiPolygon.geometry.coordinates)
     }
 }

--- a/Tests/TurfTests/PointTests.swift
+++ b/Tests/TurfTests/PointTests.swift
@@ -10,7 +10,7 @@ class PointTests: XCTestCase {
         let data = try! Fixture.geojsonData(from: "point")!
         let geojson = try! GeoJSON.parse(PointFeature.self, from: data)
         let coordinate = CLLocationCoordinate2D(latitude: 26.194876675795218, longitude: 14.765625)
-        XCTAssert(geojson.geometry?.coordinates == coordinate)
+        XCTAssert(geojson.geometry.coordinates == coordinate)
         XCTAssert((geojson.identifier!.value as! Number).value! as! Int == 1)
         
         let encodedData = try! JSONEncoder().encode(geojson)

--- a/Tests/TurfTests/PolygonTests.swift
+++ b/Tests/TurfTests/PolygonTests.swift
@@ -14,18 +14,18 @@ class PolygonTests: XCTestCase {
         let lastCoordinate = CLLocationCoordinate2D(latitude: 40.6306300839918, longitude: -108.56689453125)
         
         XCTAssert((geojson.identifier!.value as! Number).value! as! Double == 1.01)
-        XCTAssert(geojson.geometry?.outerRing.coordinates.first == firstCoordinate)
-        XCTAssert(geojson.geometry?.innerRings!.last?.coordinates.last == lastCoordinate)
-        XCTAssert(geojson.geometry?.outerRing.coordinates.count == 5)
-        XCTAssert(geojson.geometry?.innerRings!.first?.coordinates.count == 5)
+        XCTAssert(geojson.geometry.outerRing.coordinates.first == firstCoordinate)
+        XCTAssert(geojson.geometry.innerRings!.last?.coordinates.last == lastCoordinate)
+        XCTAssert(geojson.geometry.outerRing.coordinates.count == 5)
+        XCTAssert(geojson.geometry.innerRings!.first?.coordinates.count == 5)
         
         let encodedData = try! JSONEncoder().encode(geojson)
         let decoded = try! GeoJSON.parse(PolygonFeature.self, from: encodedData)
         XCTAssertEqual(geojson.geometry, decoded.geometry)
         XCTAssertEqual(geojson.identifier!.value as! Number, decoded.identifier!.value! as! Number)
-        XCTAssert(decoded.geometry?.outerRing.coordinates.first == firstCoordinate)
-        XCTAssert(decoded.geometry?.innerRings!.last?.coordinates.last == lastCoordinate)
-        XCTAssert(decoded.geometry?.outerRing.coordinates.count == 5)
-        XCTAssert(decoded.geometry?.innerRings!.first?.coordinates.count == 5)
+        XCTAssert(decoded.geometry.outerRing.coordinates.first == firstCoordinate)
+        XCTAssert(decoded.geometry.innerRings!.last?.coordinates.last == lastCoordinate)
+        XCTAssert(decoded.geometry.outerRing.coordinates.count == 5)
+        XCTAssert(decoded.geometry.innerRings!.first?.coordinates.count == 5)
     }
 }

--- a/Tests/TurfTests/TurfTests.swift
+++ b/Tests/TurfTests/TurfTests.swift
@@ -297,7 +297,7 @@ class TurfTests: XCTestCase {
            $0.map { CLLocationCoordinate2D(latitude: $0[1], longitude: $0[0]) }
         }
         
-        let polygon = Polygon(coordinates: coordinates)
+        let polygon = Polygon(coordinates)
         
         XCTAssertEqual(polygon.area, 78588446934.43, accuracy: 0.1)
     }


### PR DESCRIPTION
Top level type `Feature` and `FeatureCollection` was missing from the feature objects resulting in malformed GeoJSON data. This change fixes that and also exposes public initializers for all geometries and features and cleans up unwanted IUO.

cc @1ec5 @jmkiley 