### PR TITLE
Fixed erroneous initializer in the previous commit

### DIFF
--- a/Sources/Turf/BoundingBox.swift
+++ b/Sources/Turf/BoundingBox.swift
@@ -36,6 +36,6 @@ public struct BoundingBox: Codable {
     
     // MARK: - Private
     
-    let northWest: CLLocationCoordinate2D
-    let southEast: CLLocationCoordinate2D
+    public var northWest: CLLocationCoordinate2D
+    public var southEast: CLLocationCoordinate2D
 }

--- a/Sources/Turf/BoundingBox.swift
+++ b/Sources/Turf/BoundingBox.swift
@@ -9,8 +9,9 @@ public struct BoundingBox: Codable {
         guard coordinates?.count ?? 0 > 0 else {
             return nil
         }
+        let startValue = (minLat: coordinates!.first!.latitude, maxLat: coordinates!.first!.latitude, minLon: coordinates!.first!.longitude, maxLon: coordinates!.first!.longitude)
         let (minLat, maxLat, minLon, maxLon) = coordinates!
-            .reduce((minLat: 0, maxLat: 0, minLon: 0, maxLon: 0)) { (result, coordinate) -> (minLat: Double, maxLat: Double, minLon: Double, maxLon: Double) in
+            .reduce(startValue) { (result, coordinate) -> (minLat: Double, maxLat: Double, minLon: Double, maxLon: Double) in
                 let minLat = min(coordinate.latitude, result.0)
                 let maxLat = max(coordinate.latitude, result.1)
                 let minLon = min(coordinate.longitude, result.2)

--- a/Tests/TurfTests/BoundingBoxTests.swift
+++ b/Tests/TurfTests/BoundingBoxTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+#if !os(Linux)
+import CoreLocation
+#endif
+
+@testable import Turf
+
+class BoundingBoxTests: XCTestCase {
+    
+    func testAllPositive() {
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 1, longitude: 2),
+            CLLocationCoordinate2D(latitude: 2, longitude: 1)
+        ]
+        let bbox = BoundingBox(from: coordinates)
+        XCTAssertEqual(bbox!.northWest, CLLocationCoordinate2D(latitude: 2, longitude: 1))
+        XCTAssertEqual(bbox!.southEast, CLLocationCoordinate2D(latitude: 1, longitude: 2))
+    }
+    
+    func testAllNegative() {
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: -1, longitude: -2),
+            CLLocationCoordinate2D(latitude: -2, longitude: -1)
+        ]
+        let bbox = BoundingBox(from: coordinates)
+        XCTAssertEqual(bbox!.northWest, CLLocationCoordinate2D(latitude: -1, longitude: -2))
+        XCTAssertEqual(bbox!.southEast, CLLocationCoordinate2D(latitude: -2, longitude: -1))
+    }
+    
+    func testPositiveLatNegativeLon() {
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 1, longitude: -2),
+            CLLocationCoordinate2D(latitude: 2, longitude: -1)
+        ]
+        let bbox = BoundingBox(from: coordinates)
+        XCTAssertEqual(bbox!.northWest, CLLocationCoordinate2D(latitude: 2, longitude: -2))
+        XCTAssertEqual(bbox!.southEast, CLLocationCoordinate2D(latitude: 1, longitude: -1))
+    }
+    
+    func testNegativeLatPositiveLon() {
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: -1, longitude: 2),
+            CLLocationCoordinate2D(latitude: -2, longitude: 1)
+        ]
+        let bbox = BoundingBox(from: coordinates)
+        XCTAssertEqual(bbox!.northWest, CLLocationCoordinate2D(latitude: -1, longitude: 1))
+        XCTAssertEqual(bbox!.southEast, CLLocationCoordinate2D(latitude: -2, longitude: 2))
+    }
+}

--- a/Turf.xcodeproj/project.pbxproj
+++ b/Turf.xcodeproj/project.pbxproj
@@ -122,6 +122,9 @@
 		CE2EB999214C247100915A30 /* BoundingBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2EB997214C246A00915A30 /* BoundingBox.swift */; };
 		CE2EB99A214C247100915A30 /* BoundingBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2EB997214C246A00915A30 /* BoundingBox.swift */; };
 		CE2EB99B214C247200915A30 /* BoundingBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2EB997214C246A00915A30 /* BoundingBox.swift */; };
+		CE7F8164215182FF00A9D221 /* BoundingBoxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7F8163215182FF00A9D221 /* BoundingBoxTests.swift */; };
+		CE7F8165215182FF00A9D221 /* BoundingBoxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7F8163215182FF00A9D221 /* BoundingBoxTests.swift */; };
+		CE7F8166215182FF00A9D221 /* BoundingBoxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7F8163215182FF00A9D221 /* BoundingBoxTests.swift */; };
 		DA39EB6E20101F99004D87F7 /* Turf.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA39EB6520101F98004D87F7 /* Turf.framework */; };
 		DA39EB7C20101FB9004D87F7 /* Turf.h in Headers */ = {isa = PBXBuildFile; fileRef = 3547ECEF200C3C78009DA062 /* Turf.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA39EB7D20101FCD004D87F7 /* CoreLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3547ECF0200C3C78009DA062 /* CoreLocation.swift */; };
@@ -202,6 +205,7 @@
 		35ECAF352099EC0700DC3BC3 /* FeatureIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureIdentifier.swift; sourceTree = "<group>"; };
 		C46809D52124199500BAD5E1 /* featurecollection-no-properties.geojson */ = {isa = PBXFileReference; lastKnownFileType = text; path = "featurecollection-no-properties.geojson"; sourceTree = "<group>"; };
 		CE2EB997214C246A00915A30 /* BoundingBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoundingBox.swift; sourceTree = "<group>"; };
+		CE7F8163215182FF00A9D221 /* BoundingBoxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoundingBoxTests.swift; sourceTree = "<group>"; };
 		DA39EB6520101F98004D87F7 /* Turf.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Turf.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA39EB6D20101F99004D87F7 /* TurfTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TurfTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA94249B2010283900CDB4E6 /* Turf.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Turf.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -292,6 +296,7 @@
 			isa = PBXGroup;
 			children = (
 				3547ECFE200C3C82009DA062 /* Info.plist */,
+				CE7F8163215182FF00A9D221 /* BoundingBoxTests.swift */,
 				35B56EAE20DAF8DE00C4923D /* FeatureCollectionTests.swift */,
 				3547ECFD200C3C82009DA062 /* Fixture.swift */,
 				35B56E9A20DAF86000C4923D /* LineStringTests.swift */,
@@ -700,6 +705,7 @@
 				35B56EA020DAF88C00C4923D /* PolygonTests.swift in Sources */,
 				35B56EAC20DAF8CB00C4923D /* MultiPolygonTests.swift in Sources */,
 				35B56E9820DAF82F00C4923D /* PointTests.swift in Sources */,
+				CE7F8165215182FF00A9D221 /* BoundingBoxTests.swift in Sources */,
 				35B56EA820DAF8BB00C4923D /* MultiLineStringTests.swift in Sources */,
 				35B56EB020DAF8DE00C4923D /* FeatureCollectionTests.swift in Sources */,
 				3547ED0F200C3E01009DA062 /* TurfTests.swift in Sources */,
@@ -739,6 +745,7 @@
 				35B56E9F20DAF88C00C4923D /* PolygonTests.swift in Sources */,
 				35B56EAB20DAF8CB00C4923D /* MultiPolygonTests.swift in Sources */,
 				35B56E9720DAF82F00C4923D /* PointTests.swift in Sources */,
+				CE7F8164215182FF00A9D221 /* BoundingBoxTests.swift in Sources */,
 				35B56EA720DAF8BB00C4923D /* MultiLineStringTests.swift in Sources */,
 				35B56EAF20DAF8DE00C4923D /* FeatureCollectionTests.swift in Sources */,
 				3547ED0E200C3E00009DA062 /* TurfTests.swift in Sources */,
@@ -778,6 +785,7 @@
 				35B56EA120DAF88C00C4923D /* PolygonTests.swift in Sources */,
 				35B56EAD20DAF8CB00C4923D /* MultiPolygonTests.swift in Sources */,
 				35B56E9920DAF82F00C4923D /* PointTests.swift in Sources */,
+				CE7F8166215182FF00A9D221 /* BoundingBoxTests.swift in Sources */,
 				35B56EA920DAF8BB00C4923D /* MultiLineStringTests.swift in Sources */,
 				35B56EB120DAF8DE00C4923D /* FeatureCollectionTests.swift in Sources */,
 				DA39EB7F201023E4004D87F7 /* TurfTests.swift in Sources */,


### PR DESCRIPTION
Rebased https://github.com/mapbox/turf-swift/pull/65

Not sure how I missed this, but the default values in the reduce func in the initializer causes a lot of problems for things not bounding around the lat lon of (0, 0).

Made BoundingBox.northWest and BoundingBox.southEast public and mutable.