### PR TITLE
FeatureCollection must not contain properties

### DIFF
--- a/Sources/Turf/FeatureCollection.swift
+++ b/Sources/Turf/FeatureCollection.swift
@@ -5,11 +5,9 @@ public struct FeatureCollection: GeoJSONObject {
     public var type: FeatureType = .featureCollection
     public var identifier: FeatureIdentifier?
     public var features: Array<FeatureVariant> = []
-    public var properties: [String : AnyJSONType]?
     
     private enum CodingKeys: String, CodingKey {
         case type
-        case properties
         case features
     }
     
@@ -24,13 +22,11 @@ public struct FeatureCollection: GeoJSONObject {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.features = try container.decode([FeatureVariant].self, forKey: .features)
-        self.properties = try container.decodeIfPresent([String: AnyJSONType].self, forKey: .properties)
     }
     
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(type, forKey: .type)
         try container.encode(features, forKey: .features)
-        try container.encodeIfPresent(properties, forKey: .properties)
     }
 }

--- a/Sources/Turf/GeoJSON.swift
+++ b/Sources/Turf/GeoJSON.swift
@@ -21,10 +21,13 @@ extension FeatureType: Codable {
     }
 }
 
+public protocol GeoJSONProperties: Codable {
+    var properties: [String: AnyJSONType]? { get set }
+}
+
 public protocol GeoJSONObject: Codable {
     var type: FeatureType { get }
     var identifier: FeatureIdentifier? { get set }
-    var properties: [String: AnyJSONType]? { get set }
 }
 
 enum GeoJSONCodingKeys: String, CodingKey {

--- a/Sources/Turf/LineString.swift
+++ b/Sources/Turf/LineString.swift
@@ -16,7 +16,7 @@ public struct LineString: Codable, Equatable {
     public var coordinates: [CLLocationCoordinate2D]
 }
 
-public struct LineStringFeature: GeoJSONObject {
+public struct LineStringFeature: GeoJSONObject, GeoJSONProperties {
     public var type: FeatureType = .feature
     public var identifier: FeatureIdentifier?
     public var geometry: LineString!

--- a/Sources/Turf/MultiLineString.swift
+++ b/Sources/Turf/MultiLineString.swift
@@ -16,7 +16,7 @@ public struct MultiLineString: Codable, Equatable {
     }
 }
 
-public struct MultiLineStringFeature: GeoJSONObject {
+public struct MultiLineStringFeature: GeoJSONObject, GeoJSONProperties {
     public var type: FeatureType = .feature
     public var identifier: FeatureIdentifier?
     public var geometry: MultiLineString!

--- a/Sources/Turf/MultiPoint.swift
+++ b/Sources/Turf/MultiPoint.swift
@@ -16,7 +16,7 @@ public struct MultiPoint: Codable, Equatable {
     }
 }
 
-public struct MultiPointFeature: GeoJSONObject {
+public struct MultiPointFeature: GeoJSONObject, GeoJSONProperties {
     public var type: FeatureType = .feature
     public var identifier: FeatureIdentifier?
     public var geometry: MultiPoint

--- a/Sources/Turf/MultiPolygon.swift
+++ b/Sources/Turf/MultiPolygon.swift
@@ -16,7 +16,7 @@ public struct MultiPolygon: Codable, Equatable {
     }
 }
 
-public struct MultiPolygonFeature: GeoJSONObject {
+public struct MultiPolygonFeature: GeoJSONObject, GeoJSONProperties {
     public var type: FeatureType = .feature
     public var identifier: FeatureIdentifier?
     public var geometry: MultiPolygon

--- a/Sources/Turf/Point.swift
+++ b/Sources/Turf/Point.swift
@@ -16,7 +16,7 @@ public struct Point: Codable, Equatable {
     }
 }
 
-public struct PointFeature: GeoJSONObject {
+public struct PointFeature: GeoJSONObject, GeoJSONProperties {
     public var type: FeatureType = .feature
     public var identifier: FeatureIdentifier?
     public var geometry: Point

--- a/Sources/Turf/Polygon.swift
+++ b/Sources/Turf/Polygon.swift
@@ -24,7 +24,7 @@ public struct Polygon: Codable, Equatable {
     }
 }
 
-public struct PolygonFeature: GeoJSONObject {
+public struct PolygonFeature: GeoJSONObject, GeoJSONProperties {
     public var type: FeatureType = .feature
     public var identifier: FeatureIdentifier?
     public var geometry: Polygon


### PR DESCRIPTION
Fixes #71 

FeatureCollection must not contain geometries or properties according to https://tools.ietf.org/html/rfc7946#section-7.1

However, I'm a bit confused about turf-js’s use of properties in FeatureCollection’s here https://raw.githubusercontent.com/Turfjs/turf/17002ccd57e04e84ddb38d7e3ac8ede35b019c58/packages/turf-simplify/test/in/featurecollection.geojson

cc @1ec5 