### PR TITLE
Fix redundant coordinate at end of line slice

### DIFF
--- a/Sources/Turf/LineString.swift
+++ b/Sources/Turf/LineString.swift
@@ -189,7 +189,9 @@ extension LineString {
         
         var coords = ends.0.index == ends.1.index ? [] : Array(coordinates[ends.0.index + 1...ends.1.index])
         coords.insert(ends.0.coordinate, at: 0)
-        coords.append(ends.1.coordinate)
+        if coords.last != ends.1.coordinate {
+            coords.append(ends.1.coordinate)
+        }
         
         return LineString(coords)
     }

--- a/Tests/TurfTests/LineStringTests.swift
+++ b/Tests/TurfTests/LineStringTests.swift
@@ -295,5 +295,13 @@ class LineStringTests: XCTestCase {
         sliced = LineString(vertical).sliced(from: start, to: stop)
         XCTAssertEqual(sliced.coordinates.count, 2, "no duplicated coords")
         XCTAssertNotEqual(sliced.coordinates.first, sliced.coordinates.last, "vertical slice should not collapse to first coordinate")
+        
+        sliced = LineString(vertical).sliced(from: vertical[0], to: vertical[1])
+        XCTAssertEqual(sliced.coordinates.count, 2, "no duplicated coords")
+        XCTAssertNotEqual(sliced.coordinates.first, sliced.coordinates.last, "vertical slice should not collapse to first coordinate")
+        
+        sliced = LineString(vertical).sliced()
+        XCTAssertEqual(sliced.coordinates.count, 2, "no duplicated coords")
+        XCTAssertNotEqual(sliced.coordinates.first, sliced.coordinates.last, "vertical slice should not collapse to first coordinate")
     }
 }


### PR DESCRIPTION
Fixed an issue where `LineString.sliced(from:to:)` duplicated the last coordinate if `to` is omitted or equal to the end of the line string.

/cc @frederoni