### PR TITLE
Add conversions between polygons and line strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Turf.js | Turf-swift
 — | `CLLocationCoordinate2D.direction(to:)`<br>`RadianCoordinate2D.direction(to:)`
 — | `CLLocationDirection.difference(from:)`
 — | `CLLocationDirection.wrap(min:max:)`
+[turf-polygon-to-line](https://github.com/Turfjs/turf/tree/master/packages/turf-polygon-to-line/) | `LineString(_:)`<br>`MultiLineString(_:)`<br>`FeatureCollection(_:)`
 
 
 ## GeoJSON

--- a/Sources/Turf/FeatureCollection.swift
+++ b/Sources/Turf/FeatureCollection.swift
@@ -21,6 +21,14 @@ public struct FeatureCollection: GeoJSONObject {
         self.features = features
     }
     
+    public init(_ multiPolygon: MultiPolygon) {
+        self.features = multiPolygon.coordinates.map {
+            $0.count > 1 ?
+                .multiLineStringFeature(.init(.init($0))) :
+                .lineStringFeature(LineStringFeature(LineString($0[0])))
+        }
+    }
+    
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.features = try container.decode([FeatureVariant].self, forKey: .features)

--- a/Sources/Turf/LineString.swift
+++ b/Sources/Turf/LineString.swift
@@ -111,6 +111,13 @@ extension LineString {
     }
     
     /**
+     Initializes a LineString from the given ring.
+     */
+    public init(_ ring: Ring) {
+        self.coordinates = ring.coordinates
+    }
+    
+    /**
      Returns a coordinate along a LineString at a certain distance from the start of the polyline.
      */
     public func coordinateFromStart(distance: CLLocationDistance) -> CLLocationCoordinate2D? {

--- a/Sources/Turf/MultiLineString.swift
+++ b/Sources/Turf/MultiLineString.swift
@@ -14,6 +14,10 @@ public struct MultiLineString: Codable, Equatable {
     public init(_ coordinates: [[CLLocationCoordinate2D]]) {
         self.coordinates = coordinates
     }
+    
+    public init(_ polygon: Polygon) {
+        self.coordinates = polygon.coordinates
+    }
 }
 
 public struct MultiLineStringFeature: GeoJSONObject {


### PR DESCRIPTION
Added initializers based on the [polygon-to-line](https://github.com/Turfjs/turf/tree/b6cb691e0d23293ca0c881fe561f0e8a4536ad6a/packages/turf-polygon-to-line) package to convert from Ring to LineString, from Polygon to MultiLineString, and from MultiPolygon to a FeatureCollection containing a mixture of LineStringFeatures and MultiLineStringFeatures.

Fixes #81.

/cc @samfader @frederoni