### PR TITLE
Fix Polygon.contains

### DIFF
--- a/Sources/Turf/BoundingBox.swift
+++ b/Sources/Turf/BoundingBox.swift
@@ -27,11 +27,18 @@ public struct BoundingBox: Codable {
         self.southEast = southEast
     }
     
-    public func contains(_ coordinate: CLLocationCoordinate2D) -> Bool {
-        return southEast.latitude < coordinate.latitude
-            && northWest.latitude > coordinate.latitude
-            && northWest.longitude < coordinate.longitude
-            && southEast.longitude > coordinate.longitude
+    public func contains(_ coordinate: CLLocationCoordinate2D, ignoreBoundary: Bool = true) -> Bool {
+        if ignoreBoundary {
+            return southEast.latitude < coordinate.latitude
+                && northWest.latitude > coordinate.latitude
+                && northWest.longitude < coordinate.longitude
+                && southEast.longitude > coordinate.longitude
+        } else {
+            return southEast.latitude <= coordinate.latitude
+                && northWest.latitude >= coordinate.latitude
+                && northWest.longitude <= coordinate.longitude
+                && southEast.longitude >= coordinate.longitude
+        }
     }
     
     // MARK: - Codable

--- a/Sources/Turf/Polygon.swift
+++ b/Sources/Turf/Polygon.swift
@@ -32,10 +32,6 @@ extension Geometry.PolygonRepresentation {
     ///
     ///Ported from: https://github.com/Turfjs/turf/blob/e53677b0931da9e38bb947da448ee7404adc369d/packages/turf-boolean-point-in-polygon/index.ts#L31-L75
     public func contains(_ coordinate: CLLocationCoordinate2D, ignoreBoundary: Bool = false) -> Bool {
-        let bbox = BoundingBox(from: coordinates.first)
-        guard bbox?.contains(coordinate, ignoreBoundary: ignoreBoundary) ?? false else {
-            return false
-        }
         guard outerRing.contains(coordinate, ignoreBoundary: ignoreBoundary) else {
             return false
         }

--- a/Sources/Turf/Polygon.swift
+++ b/Sources/Turf/Polygon.swift
@@ -36,7 +36,7 @@ extension Geometry.PolygonRepresentation {
             return false
         }
         for ring in innerRings {
-            if ring.contains(coordinate, ignoreBoundary: ignoreBoundary) {
+            if ring.contains(coordinate, ignoreBoundary: !ignoreBoundary) {
                 return false
             }
         }

--- a/Sources/Turf/Polygon.swift
+++ b/Sources/Turf/Polygon.swift
@@ -33,7 +33,7 @@ extension Geometry.PolygonRepresentation {
     ///Ported from: https://github.com/Turfjs/turf/blob/e53677b0931da9e38bb947da448ee7404adc369d/packages/turf-boolean-point-in-polygon/index.ts#L31-L75
     public func contains(_ coordinate: CLLocationCoordinate2D, ignoreBoundary: Bool = false) -> Bool {
         let bbox = BoundingBox(from: coordinates.first)
-        guard bbox?.contains(coordinate) ?? false else {
+        guard bbox?.contains(coordinate, ignoreBoundary: ignoreBoundary) ?? false else {
             return false
         }
         guard outerRing.contains(coordinate, ignoreBoundary: ignoreBoundary) else {

--- a/Sources/Turf/Ring.swift
+++ b/Sources/Turf/Ring.swift
@@ -63,6 +63,11 @@ extension Ring {
      * Ported from: https://github.com/Turfjs/turf/blob/e53677b0931da9e38bb947da448ee7404adc369d/packages/turf-boolean-point-in-polygon/index.ts#L77-L108
      */
     public func contains(_ coordinate: CLLocationCoordinate2D, ignoreBoundary: Bool = false) -> Bool {
+        let bbox = BoundingBox(from: coordinates)
+        guard bbox?.contains(coordinate, ignoreBoundary: ignoreBoundary) ?? false else {
+            return false
+        }
+
         var ring: ArraySlice<CLLocationCoordinate2D>!
         var isInside = false
         if coordinates.first == coordinates.last {

--- a/Tests/TurfTests/BoundingBoxTests.swift
+++ b/Tests/TurfTests/BoundingBoxTests.swift
@@ -46,4 +46,39 @@ class BoundingBoxTests: XCTestCase {
         XCTAssertEqual(bbox!.northWest, CLLocationCoordinate2D(latitude: -1, longitude: 1))
         XCTAssertEqual(bbox!.southEast, CLLocationCoordinate2D(latitude: -2, longitude: 2))
     }
+
+    func testContains() {
+        let coordinate = CLLocationCoordinate2D(latitude: 1, longitude: 1)
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 0, longitude: 0),
+            CLLocationCoordinate2D(latitude: 2, longitude: 2)
+        ]
+        let bbox = BoundingBox(from: coordinates)
+
+        XCTAssertTrue(bbox!.contains(coordinate))
+    }
+
+    func testDoesNotContain() {
+        let coordinate = CLLocationCoordinate2D(latitude: 2, longitude: 3)
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 0, longitude: 0),
+            CLLocationCoordinate2D(latitude: 2, longitude: 2)
+        ]
+        let bbox = BoundingBox(from: coordinates)
+
+        XCTAssertFalse(bbox!.contains(coordinate))
+    }
+
+    func testContainsAtBoundary() {
+        let coordinate = CLLocationCoordinate2D(latitude: 0, longitude: 2)
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 0, longitude: 0),
+            CLLocationCoordinate2D(latitude: 2, longitude: 2)
+        ]
+        let bbox = BoundingBox(from: coordinates)
+
+        XCTAssertFalse(bbox!.contains(coordinate, ignoreBoundary: true))
+        XCTAssertTrue(bbox!.contains(coordinate, ignoreBoundary: false))
+        XCTAssertFalse(bbox!.contains(coordinate))
+    }
 }

--- a/Tests/TurfTests/PolygonTests.swift
+++ b/Tests/TurfTests/PolygonTests.swift
@@ -98,4 +98,28 @@ class PolygonTests: XCTestCase {
         XCTAssertTrue(polygon.contains(coordinate, ignoreBoundary: false))
         XCTAssertTrue(polygon.contains(coordinate))
     }
+
+    func testPolygonWithHoleContainsAtBoundary() {
+        let coordinate = CLLocationCoordinate2D(latitude: 43, longitude: -78)
+        let polygon = Geometry.PolygonRepresentation([
+            [
+                CLLocationCoordinate2D(latitude: 41, longitude: -81),
+                CLLocationCoordinate2D(latitude: 47, longitude: -81),
+                CLLocationCoordinate2D(latitude: 47, longitude: -72),
+                CLLocationCoordinate2D(latitude: 41, longitude: -72),
+                CLLocationCoordinate2D(latitude: 41, longitude: -81),
+            ],
+            [
+                CLLocationCoordinate2D(latitude: 43, longitude: -76),
+                CLLocationCoordinate2D(latitude: 43, longitude: -78),
+                CLLocationCoordinate2D(latitude: 45, longitude: -78),
+                CLLocationCoordinate2D(latitude: 45, longitude: -76),
+                CLLocationCoordinate2D(latitude: 43, longitude: -76),
+            ],
+        ])
+
+        XCTAssertFalse(polygon.contains(coordinate, ignoreBoundary: true))
+        XCTAssertTrue(polygon.contains(coordinate, ignoreBoundary: false))
+        XCTAssertTrue(polygon.contains(coordinate))
+    }
 }

--- a/Tests/TurfTests/PolygonTests.swift
+++ b/Tests/TurfTests/PolygonTests.swift
@@ -83,4 +83,19 @@ class PolygonTests: XCTestCase {
         ])
         XCTAssertFalse(polygon.contains(coordinate))
     }
+
+    func testPolygonContainsAtBoundary() {
+        let coordinate = CLLocationCoordinate2D(latitude: 1, longitude: 1)
+        let polygon = Geometry.PolygonRepresentation([[
+            CLLocationCoordinate2D(latitude: 0, longitude: 0),
+            CLLocationCoordinate2D(latitude: 1, longitude: 0),
+            CLLocationCoordinate2D(latitude: 1, longitude: 1),
+            CLLocationCoordinate2D(latitude: 0, longitude: 1),
+            CLLocationCoordinate2D(latitude: 0, longitude: 0),
+            ]])
+
+        XCTAssertFalse(polygon.contains(coordinate, ignoreBoundary: true))
+        XCTAssertTrue(polygon.contains(coordinate, ignoreBoundary: false))
+        XCTAssertTrue(polygon.contains(coordinate))
+    }
 }


### PR DESCRIPTION
Fixes #88

-   **Fix `Polygon.contains` at boundary**

    `Polygon.contains(_:ignoreBoundary:)` with `ignoreBoundary` set to `false` (the default), was returning `false` for a point at the boundary that coincides with the bounding box. This is because the optimization that first checks whether the point is contained by the polygon's bounding box, which uses `BoundingBox.contains(_:)`, did not consider a point at the boundary as being contained.

    To address this, `BoundingBox.contains(_:)` is extended with a second argument `ignoreBoundary` defaulting to `true` for backwards compatibility.  The optimization in `Polygon.contains(_:ignoreBoundary:)` now forwards the `ignoreBoundary` argument, fixing the issue.

-   **Move containment optimization from `Polygon` to `Ring`**

    `Polygon.contains(_:ignoreBoundary:)` first checks whether its bounding box contains the point before proceeding with a more expensive and complete check. For polygons with holes, each hole could benefit from this optimization. In other words, the outer ring as well as all inner rings can benefit from this optimization.

    This commit accomplishes this by moving the bounding box optimization to `Ring.contains(_:ignoreBoundary:)`.

-   **Fix `Polygon.contains` at boundary of hole**

    When including the boundary, a point at the boundary of a hole is considered to be contained by the polygon. Conversely, when not including the boundary a point at the boundary of a hole is considered not to be contained by the polygon.

    Neither of those were the case as shown by the added test. The fix is as simple as flipping the `ignoreBoundary` flag when checking whether the point is within one of the holes.