### PR TITLE
CLLocationCoordinate Codable private conformance

### DIFF
--- a/Sources/Turf/BoundingBox.swift
+++ b/Sources/Turf/BoundingBox.swift
@@ -34,6 +34,20 @@ public struct BoundingBox: Codable {
             && southEast.longitude > coordinate.longitude
     }
     
+    // MARK: - Codable
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(northWest.codableCoordinates)
+        try container.encode(southEast.codableCoordinates)
+    }
+    
+    public init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        northWest = try container.decode(CLLocationCoordinate2DCodable.self).decodedCoordinates
+        southEast = try container.decode(CLLocationCoordinate2DCodable.self).decodedCoordinates
+    }
+    
     // MARK: - Private
     
     public var northWest: CLLocationCoordinate2D

--- a/Sources/Turf/Codable.swift
+++ b/Sources/Turf/Codable.swift
@@ -72,12 +72,12 @@ public struct AnyJSONType: JSONType {
 extension Ring: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        self = Ring(coordinates: try container.decode([CLLocationCoordinate2D].self))
+        self = Ring(coordinates: try container.decode([CLLocationCoordinate2DCodable].self).decodedCoordinates)
     }
     
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
-        try container.encode(coordinates)
+        try container.encode(coordinates.codableCoordinates)
     }
 }
 

--- a/Sources/Turf/CoreLocation.swift
+++ b/Sources/Turf/CoreLocation.swift
@@ -50,18 +50,71 @@ extension CLLocationDirection {
     }
 }
 
-extension CLLocationCoordinate2D: Codable {
-    public func encode(to encoder: Encoder) throws {
+struct CLLocationCoordinate2DCodable: Codable {
+    var latitude: CLLocationDegrees
+    var longitude: CLLocationDegrees
+    var decodedCoordinates: CLLocationCoordinate2D {
+        return CLLocationCoordinate2D(latitude: latitude,
+                                      longitude: longitude)
+    }
+    
+    func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
         try container.encode(longitude)
         try container.encode(latitude)
     }
     
-    public init(from decoder: Decoder) throws {
+    init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()
-        let longitude = try container.decode(CLLocationDegrees.self)
-        let latitude = try container.decode(CLLocationDegrees.self)
-        self.init(latitude: latitude, longitude: longitude)
+        longitude = try container.decode(CLLocationDegrees.self)
+        latitude = try container.decode(CLLocationDegrees.self)
+    }
+    
+    init(_ coordinate: CLLocationCoordinate2D) {
+        latitude = coordinate.latitude
+        longitude = coordinate.longitude
+    }
+}
+
+extension CLLocationCoordinate2D {
+    var codableCoordinates: CLLocationCoordinate2DCodable {
+        return CLLocationCoordinate2DCodable(self)
+    }
+}
+
+extension Array where Element == CLLocationCoordinate2DCodable {
+    var decodedCoordinates: [CLLocationCoordinate2D] {
+        return map { $0.decodedCoordinates }
+    }
+}
+
+extension Array where Element == [CLLocationCoordinate2DCodable] {
+    var decodedCoordinates: [[CLLocationCoordinate2D]] {
+        return map { $0.decodedCoordinates }
+    }
+}
+
+extension Array where Element == [[CLLocationCoordinate2DCodable]] {
+    var decodedCoordinates: [[[CLLocationCoordinate2D]]] {
+        return map { $0.decodedCoordinates }
+    }
+}
+
+extension Array where Element == CLLocationCoordinate2D {
+    var codableCoordinates: [CLLocationCoordinate2DCodable] {
+        return map { $0.codableCoordinates }
+    }
+}
+
+extension Array where Element == [CLLocationCoordinate2D] {
+    var codableCoordinates: [[CLLocationCoordinate2DCodable]] {
+        return map { $0.codableCoordinates }
+    }
+}
+
+extension Array where Element == [[CLLocationCoordinate2D]] {
+    var codableCoordinates: [[[CLLocationCoordinate2DCodable]]] {
+        return map { $0.codableCoordinates }
     }
 }
 

--- a/Sources/Turf/Geometry.swift
+++ b/Sources/Turf/Geometry.swift
@@ -133,22 +133,22 @@ extension Geometry: Codable {
             
             switch type {
             case .Point:
-                let coordinates = try container.decode(CLLocationCoordinate2D.self, forKey: .coordinates)
+                let coordinates = try container.decode(CLLocationCoordinate2DCodable.self, forKey: .coordinates).decodedCoordinates
                 self = .Point(coordinates: PointRepresentation(coordinates))
             case .LineString:
-                let coordinates = try container.decode([CLLocationCoordinate2D].self, forKey: .coordinates)
+                let coordinates = try container.decode([CLLocationCoordinate2DCodable].self, forKey: .coordinates).decodedCoordinates
                 self = .LineString(coordinates: LineStringRepresentation(coordinates))
             case .Polygon:
-                let coordinates = try container.decode([[CLLocationCoordinate2D]].self, forKey: .coordinates)
+                let coordinates = try container.decode([[CLLocationCoordinate2DCodable]].self, forKey: .coordinates).decodedCoordinates
                 self = .Polygon(coordinates: PolygonRepresentation(coordinates))
             case .MultiPoint:
-                let coordinates = try container.decode([CLLocationCoordinate2D].self, forKey: .coordinates)
+                let coordinates = try container.decode([CLLocationCoordinate2DCodable].self, forKey: .coordinates).decodedCoordinates
                 self = .MultiPoint(coordinates: MultiPointRepresentation(coordinates))
             case .MultiLineString:
-                let coordinates = try container.decode([[CLLocationCoordinate2D]].self, forKey: .coordinates)
+                let coordinates = try container.decode([[CLLocationCoordinate2DCodable]].self, forKey: .coordinates).decodedCoordinates
                 self = .MultiLineString(coordinates: MultiLineStringRepresentation(coordinates))
             case .MultiPolygon:
-                let coordinates = try container.decode([[[CLLocationCoordinate2D]]].self, forKey: .coordinates)
+                let coordinates = try container.decode([[[CLLocationCoordinate2DCodable]]].self, forKey: .coordinates).decodedCoordinates
                 self = .MultiPolygon(coordinates: MultiPolygonRepresentation(coordinates))
             case .GeometryCollection:
                 let geometries = try container.decode([Geometry].self, forKey: .geometries)
@@ -162,17 +162,17 @@ extension Geometry: Codable {
             
             switch self {
             case .Point(let representation):
-                try container.encode(representation.coordinates, forKey: .coordinates)
+                try container.encode(representation.coordinates.codableCoordinates, forKey: .coordinates)
             case .LineString(let representation):
-                try container.encode(representation.coordinates, forKey: .coordinates)
+                try container.encode(representation.coordinates.codableCoordinates, forKey: .coordinates)
             case .Polygon(let representation):
-                try container.encode(representation.coordinates, forKey: .coordinates)
+                try container.encode(representation.coordinates.codableCoordinates, forKey: .coordinates)
             case .MultiPoint(let representation):
-                try container.encode(representation.coordinates, forKey: .coordinates)
+                try container.encode(representation.coordinates.codableCoordinates, forKey: .coordinates)
             case .MultiLineString(let representation):
-                try container.encode(representation.coordinates, forKey: .coordinates)
+                try container.encode(representation.coordinates.codableCoordinates, forKey: .coordinates)
             case .MultiPolygon(let representation):
-                try container.encode(representation.coordinates, forKey: .coordinates)
+                try container.encode(representation.coordinates.codableCoordinates, forKey: .coordinates)
             case .GeometryCollection(let representation):
                 try container.encode(representation.geometries, forKey: .geometries)
             }


### PR DESCRIPTION
Resolves #84 
Removed `CLLocationCoordinate` `Codable` conformance. 
Since there is no such thing as "Private protocol conformance" in Swift, I implemented `CLLocationCoordinate2DCodable` wrapper to handle encoding and decoding. This solution allows smooth en|decoding of `CLLocationCoordinate` inside `Turf`, and allows user to implement their own `Codable` conformance if they need to.