### PR TITLE
Apply Swift naming conventions to GeoJSON initializers

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ let geojson = try! GeoJSON.parse(FeatureCollection.self, from: data)
 // Initialize a PointFeature and encode as GeoJSON
 let coordinate = CLLocationCoordinate2D(latitude: 0, longitude: 1)
 let point = Point(coordinate)
-let pointFeature = Feature(geometry: .Point(point))
+let pointFeature = Feature(geometry: .point(point))
 let data = try! JSONEncoder().encode(pointFeature)
 let json = String(data: data, encoding: .utf8)
 print(json)

--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ let geojson = try! GeoJSON.parse(FeatureCollection.self, from: data)
 
 // Initialize a PointFeature and encode as GeoJSON
 let coordinate = CLLocationCoordinate2D(latitude: 0, longitude: 1)
-let point = Geometry.Point(coordinates: .init(coordinate))
-let pointFeature = Feature(point)
+let point = Point(coordinate)
+let pointFeature = Feature(geometry: .Point(point))
 let data = try! JSONEncoder().encode(pointFeature)
 let json = String(data: data, encoding: .utf8)
 print(json)

--- a/Sources/Turf/Feature.swift
+++ b/Sources/Turf/Feature.swift
@@ -17,7 +17,7 @@ public struct Feature: GeoJSONObject {
             case identifier = "id"
     }
     
-    public init(_ geometry: Geometry) {
+    public init(geometry: Geometry) {
         self.geometry = geometry
     }
     

--- a/Sources/Turf/FeatureCollection.swift
+++ b/Sources/Turf/FeatureCollection.swift
@@ -13,7 +13,7 @@ public struct FeatureCollection: GeoJSONObject {
         case features
     }
     
-    public init(_ features: [Feature]) {
+    public init(features: [Feature]) {
         self.features = features
     }
     

--- a/Sources/Turf/Geometries/GeometryCollection.swift
+++ b/Sources/Turf/Geometries/GeometryCollection.swift
@@ -14,8 +14,8 @@ public struct GeometryCollection {
     public init(_ multiPolygon: MultiPolygon) {
         self.geometries = multiPolygon.coordinates.map {
             $0.count > 1 ?
-                .MultiLineString(coordinates: .init($0)) :
-                .LineString(coordinates:  .init($0[0]))
+                .multiLineString(.init($0)) :
+                .lineString(.init($0[0]))
         }
     }
 }

--- a/Sources/Turf/Geometries/GeometryCollection.swift
+++ b/Sources/Turf/Geometries/GeometryCollection.swift
@@ -7,7 +7,7 @@ import CoreLocation
 public struct GeometryCollection {
     public let geometries: [Geometry]
     
-    public init(_ geometries: [Geometry]) {
+    public init(geometries: [Geometry]) {
         self.geometries = geometries
     }
     

--- a/Sources/Turf/Geometry.swift
+++ b/Sources/Turf/Geometry.swift
@@ -21,13 +21,13 @@ public enum Geometry {
         case geometries
     }
     
-    case Point(coordinates: Point)
-    case LineString(coordinates: LineString)
-    case Polygon(coordinates: Polygon)
-    case MultiPoint(coordinates: MultiPoint)
-    case MultiLineString(coordinates: MultiLineString)
-    case MultiPolygon(coordinates: MultiPolygon)
-    case GeometryCollection(geometries: GeometryCollection)
+    case Point(_ geometry: Point)
+    case LineString(_ geometry: LineString)
+    case Polygon(_ geometry: Polygon)
+    case MultiPoint(_ geometry: MultiPoint)
+    case MultiLineString(_ geometry: MultiLineString)
+    case MultiPolygon(_ geometry: MultiPolygon)
+    case GeometryCollection(_ geometry: GeometryCollection)
     
     public var type: GeometryType {
         switch self {
@@ -77,25 +77,25 @@ extension Geometry: Codable {
             switch type {
             case .Point:
                 let coordinates = try container.decode(CLLocationCoordinate2DCodable.self, forKey: .coordinates).decodedCoordinates
-                self = .Point(coordinates: .init(coordinates))
+                self = .Point(.init(coordinates))
             case .LineString:
                 let coordinates = try container.decode([CLLocationCoordinate2DCodable].self, forKey: .coordinates).decodedCoordinates
-                self = .LineString(coordinates: .init(coordinates))
+                self = .LineString(.init(coordinates))
             case .Polygon:
                 let coordinates = try container.decode([[CLLocationCoordinate2DCodable]].self, forKey: .coordinates).decodedCoordinates
-                self = .Polygon(coordinates: .init(coordinates))
+                self = .Polygon(.init(coordinates))
             case .MultiPoint:
                 let coordinates = try container.decode([CLLocationCoordinate2DCodable].self, forKey: .coordinates).decodedCoordinates
-                self = .MultiPoint(coordinates: .init(coordinates))
+                self = .MultiPoint(.init(coordinates))
             case .MultiLineString:
                 let coordinates = try container.decode([[CLLocationCoordinate2DCodable]].self, forKey: .coordinates).decodedCoordinates
-                self = .MultiLineString(coordinates: .init(coordinates))
+                self = .MultiLineString(.init(coordinates))
             case .MultiPolygon:
                 let coordinates = try container.decode([[[CLLocationCoordinate2DCodable]]].self, forKey: .coordinates).decodedCoordinates
-                self = .MultiPolygon(coordinates: .init(coordinates))
+                self = .MultiPolygon(.init(coordinates))
             case .GeometryCollection:
                 let geometries = try container.decode([Geometry].self, forKey: .geometries)
-                self = .GeometryCollection(geometries: .init(geometries))
+                self = .GeometryCollection(.init(geometries: geometries))
             }
         }
         

--- a/Sources/Turf/Geometry.swift
+++ b/Sources/Turf/Geometry.swift
@@ -21,48 +21,48 @@ public enum Geometry {
         case geometries
     }
     
-    case Point(_ geometry: Point)
-    case LineString(_ geometry: LineString)
-    case Polygon(_ geometry: Polygon)
-    case MultiPoint(_ geometry: MultiPoint)
-    case MultiLineString(_ geometry: MultiLineString)
-    case MultiPolygon(_ geometry: MultiPolygon)
-    case GeometryCollection(_ geometry: GeometryCollection)
+    case point(_ geometry: Point)
+    case lineString(_ geometry: LineString)
+    case polygon(_ geometry: Polygon)
+    case multiPoint(_ geometry: MultiPoint)
+    case multiLineString(_ geometry: MultiLineString)
+    case multiPolygon(_ geometry: MultiPolygon)
+    case geometryCollection(_ geometry: GeometryCollection)
     
     public var type: GeometryType {
         switch self {
-        case .Point(_):
+        case .point(_):
             return .Point
-        case .LineString(_):
+        case .lineString(_):
             return .LineString
-        case .Polygon(_):
+        case .polygon(_):
             return .Polygon
-        case .MultiPoint(_):
+        case .multiPoint(_):
             return .MultiPoint
-        case .MultiLineString(_):
+        case .multiLineString(_):
             return .MultiLineString
-        case .MultiPolygon(_):
+        case .multiPolygon(_):
             return .MultiPolygon
-        case .GeometryCollection(_):
+        case .geometryCollection(_):
             return .GeometryCollection
         }
     }
     
     public var value: Any? {
         switch self {
-        case .Point(let value):
+        case .point(let value):
             return value
-        case .LineString(let value):
+        case .lineString(let value):
             return value
-        case .Polygon(let value):
+        case .polygon(let value):
             return value
-        case .MultiPoint(let value):
+        case .multiPoint(let value):
             return value
-        case .MultiLineString(let value):
+        case .multiLineString(let value):
             return value
-        case .MultiPolygon(let value):
+        case .multiPolygon(let value):
             return value
-        case .GeometryCollection(let value):
+        case .geometryCollection(let value):
             return value
         }
     }
@@ -77,25 +77,25 @@ extension Geometry: Codable {
             switch type {
             case .Point:
                 let coordinates = try container.decode(CLLocationCoordinate2DCodable.self, forKey: .coordinates).decodedCoordinates
-                self = .Point(.init(coordinates))
+                self = .point(.init(coordinates))
             case .LineString:
                 let coordinates = try container.decode([CLLocationCoordinate2DCodable].self, forKey: .coordinates).decodedCoordinates
-                self = .LineString(.init(coordinates))
+                self = .lineString(.init(coordinates))
             case .Polygon:
                 let coordinates = try container.decode([[CLLocationCoordinate2DCodable]].self, forKey: .coordinates).decodedCoordinates
-                self = .Polygon(.init(coordinates))
+                self = .polygon(.init(coordinates))
             case .MultiPoint:
                 let coordinates = try container.decode([CLLocationCoordinate2DCodable].self, forKey: .coordinates).decodedCoordinates
-                self = .MultiPoint(.init(coordinates))
+                self = .multiPoint(.init(coordinates))
             case .MultiLineString:
                 let coordinates = try container.decode([[CLLocationCoordinate2DCodable]].self, forKey: .coordinates).decodedCoordinates
-                self = .MultiLineString(.init(coordinates))
+                self = .multiLineString(.init(coordinates))
             case .MultiPolygon:
                 let coordinates = try container.decode([[[CLLocationCoordinate2DCodable]]].self, forKey: .coordinates).decodedCoordinates
-                self = .MultiPolygon(.init(coordinates))
+                self = .multiPolygon(.init(coordinates))
             case .GeometryCollection:
                 let geometries = try container.decode([Geometry].self, forKey: .geometries)
-                self = .GeometryCollection(.init(geometries: geometries))
+                self = .geometryCollection(.init(geometries: geometries))
             }
         }
         
@@ -104,19 +104,19 @@ extension Geometry: Codable {
             try container.encode(type.rawValue, forKey: .type)
             
             switch self {
-            case .Point(let representation):
+            case .point(let representation):
                 try container.encode(representation.coordinates.codableCoordinates, forKey: .coordinates)
-            case .LineString(let representation):
+            case .lineString(let representation):
                 try container.encode(representation.coordinates.codableCoordinates, forKey: .coordinates)
-            case .Polygon(let representation):
+            case .polygon(let representation):
                 try container.encode(representation.coordinates.codableCoordinates, forKey: .coordinates)
-            case .MultiPoint(let representation):
+            case .multiPoint(let representation):
                 try container.encode(representation.coordinates.codableCoordinates, forKey: .coordinates)
-            case .MultiLineString(let representation):
+            case .multiLineString(let representation):
                 try container.encode(representation.coordinates.codableCoordinates, forKey: .coordinates)
-            case .MultiPolygon(let representation):
+            case .multiPolygon(let representation):
                 try container.encode(representation.coordinates.codableCoordinates, forKey: .coordinates)
-            case .GeometryCollection(let representation):
+            case .geometryCollection(let representation):
                 try container.encode(representation.geometries, forKey: .geometries)
             }
         }

--- a/Tests/TurfTests/FeatureCollectionTests.swift
+++ b/Tests/TurfTests/FeatureCollectionTests.swift
@@ -16,7 +16,7 @@ class FeatureCollectionTests: XCTestCase {
         XCTAssert(geojson.features[3].geometry.type == .Point)
         
         let lineStringFeature = geojson.features[0]
-        guard case let .LineString(lineStringCoordinates) = lineStringFeature.geometry else {
+        guard case let .lineString(lineStringCoordinates) = lineStringFeature.geometry else {
             XCTFail()
             return
         }
@@ -26,7 +26,7 @@ class FeatureCollectionTests: XCTestCase {
         XCTAssert(lineStringCoordinates.coordinates.first!.longitude == 27.977542877197266)
         
         let polygonFeature = geojson.features[1]
-        guard case let .Polygon(polygonCoordinates) = polygonFeature.geometry else {
+        guard case let .polygon(polygonCoordinates) = polygonFeature.geometry else {
             XCTFail()
             return
         }
@@ -36,7 +36,7 @@ class FeatureCollectionTests: XCTestCase {
         XCTAssert(polygonCoordinates.coordinates[0].first!.longitude == 27.972049713134762)
         
         let pointFeature = geojson.features[3]
-        guard case let .Point(pointCoordinates) = pointFeature.geometry else {
+        guard case let .point(pointCoordinates) = pointFeature.geometry else {
             XCTFail()
             return
         }
@@ -53,7 +53,7 @@ class FeatureCollectionTests: XCTestCase {
         XCTAssert(decoded.features[3].geometry.type == .Point)
         
         let decodedLineStringFeature = decoded.features[0]
-        guard case let .LineString(decodedLineStringCoordinates) = decodedLineStringFeature.geometry else {
+        guard case let .lineString(decodedLineStringCoordinates) = decodedLineStringFeature.geometry else {
                    XCTFail()
                    return
                }
@@ -63,7 +63,7 @@ class FeatureCollectionTests: XCTestCase {
         XCTAssert(decodedLineStringCoordinates.coordinates.first!.longitude == 27.977542877197266)
         
         let decodedPolygonFeature = decoded.features[1]
-        guard case let .Polygon(decodedPolygonCoordinates) = decodedPolygonFeature.geometry else {
+        guard case let .polygon(decodedPolygonCoordinates) = decodedPolygonFeature.geometry else {
             XCTFail()
             return
         }
@@ -73,7 +73,7 @@ class FeatureCollectionTests: XCTestCase {
         XCTAssert(decodedPolygonCoordinates.coordinates[0].first!.longitude == 27.972049713134762)
         
         let decodedPointFeature = decoded.features[3]
-        guard case let .Point(decodedPointCoordinates) = decodedPointFeature.geometry else {
+        guard case let .point(decodedPointCoordinates) = decodedPointFeature.geometry else {
             XCTFail()
             return
         }

--- a/Tests/TurfTests/GeoJSONTests.swift
+++ b/Tests/TurfTests/GeoJSONTests.swift
@@ -9,7 +9,7 @@ class GeoJSONTests: XCTestCase {
     
     func testPoint() {
         let coordinate = CLLocationCoordinate2D(latitude: 10, longitude: 30)
-        let geometry = Geometry.Point(Point(coordinate))
+        let geometry = Geometry.point(Point(coordinate))
         let pointFeature = Feature(geometry: geometry)
         
         XCTAssertEqual((pointFeature.geometry.value as! Point).coordinates, coordinate)
@@ -20,7 +20,7 @@ class GeoJSONTests: XCTestCase {
                            CLLocationCoordinate2D(latitude: 30, longitude: 10),
                            CLLocationCoordinate2D(latitude: 40, longitude: 40)]
         
-        let lineString = Geometry.LineString(.init(coordinates))
+        let lineString = Geometry.lineString(.init(coordinates))
         let lineStringFeature = Feature(geometry: lineString)
         XCTAssertEqual((lineStringFeature.geometry.value as! LineString).coordinates, coordinates)
     }
@@ -42,7 +42,7 @@ class GeoJSONTests: XCTestCase {
             ]
         ]
         
-        let polygon = Geometry.Polygon(.init(coordinates))
+        let polygon = Geometry.polygon(.init(coordinates))
         let polygonFeature = Feature(geometry: polygon)
         XCTAssertEqual((polygonFeature.geometry.value as! Polygon).coordinates, coordinates)
     }
@@ -53,7 +53,7 @@ class GeoJSONTests: XCTestCase {
                            CLLocationCoordinate2D(latitude: 20, longitude: 20),
                            CLLocationCoordinate2D(latitude: 10, longitude: 30)]
         
-        let multiPoint = Geometry.MultiPoint(.init(coordinates))
+        let multiPoint = Geometry.multiPoint(.init(coordinates))
         let multiPointFeature = Feature(geometry: multiPoint)
         XCTAssertEqual((multiPointFeature.geometry.value as! MultiPoint).coordinates, coordinates)
     }
@@ -73,7 +73,7 @@ class GeoJSONTests: XCTestCase {
             ]
         ]
         
-        let multiLineString = Geometry.MultiLineString(.init(coordinates))
+        let multiLineString = Geometry.multiLineString(.init(coordinates))
         let multiLineStringFeature = Feature(geometry: multiLineString)
         XCTAssertEqual((multiLineStringFeature.geometry.value as! MultiLineString).coordinates, coordinates)
     }
@@ -106,7 +106,7 @@ class GeoJSONTests: XCTestCase {
             ]
         ]
         
-        let multiPolygon = Geometry.MultiPolygon(.init(coordinates))
+        let multiPolygon = Geometry.multiPolygon(.init(coordinates))
         let multiPolygonFeature = Feature(geometry: multiPolygon)
         XCTAssertEqual((multiPolygonFeature.geometry.value as! MultiPolygon).coordinates, coordinates)
     }

--- a/Tests/TurfTests/GeoJSONTests.swift
+++ b/Tests/TurfTests/GeoJSONTests.swift
@@ -9,8 +9,8 @@ class GeoJSONTests: XCTestCase {
     
     func testPoint() {
         let coordinate = CLLocationCoordinate2D(latitude: 10, longitude: 30)
-        let geometry = Geometry.Point(coordinates: Point(coordinate))
-        let pointFeature = Feature(geometry)
+        let geometry = Geometry.Point(Point(coordinate))
+        let pointFeature = Feature(geometry: geometry)
         
         XCTAssertEqual((pointFeature.geometry.value as! Point).coordinates, coordinate)
     }
@@ -20,8 +20,8 @@ class GeoJSONTests: XCTestCase {
                            CLLocationCoordinate2D(latitude: 30, longitude: 10),
                            CLLocationCoordinate2D(latitude: 40, longitude: 40)]
         
-        let lineString = Geometry.LineString(coordinates: .init(coordinates))
-        let lineStringFeature = Feature(lineString)
+        let lineString = Geometry.LineString(.init(coordinates))
+        let lineStringFeature = Feature(geometry: lineString)
         XCTAssertEqual((lineStringFeature.geometry.value as! LineString).coordinates, coordinates)
     }
     
@@ -42,8 +42,8 @@ class GeoJSONTests: XCTestCase {
             ]
         ]
         
-        let polygon = Geometry.Polygon(coordinates: .init(coordinates))
-        let polygonFeature = Feature(polygon)
+        let polygon = Geometry.Polygon(.init(coordinates))
+        let polygonFeature = Feature(geometry: polygon)
         XCTAssertEqual((polygonFeature.geometry.value as! Polygon).coordinates, coordinates)
     }
     
@@ -53,8 +53,8 @@ class GeoJSONTests: XCTestCase {
                            CLLocationCoordinate2D(latitude: 20, longitude: 20),
                            CLLocationCoordinate2D(latitude: 10, longitude: 30)]
         
-        let multiPoint = Geometry.MultiPoint(coordinates: .init(coordinates))
-        let multiPointFeature = Feature(multiPoint)
+        let multiPoint = Geometry.MultiPoint(.init(coordinates))
+        let multiPointFeature = Feature(geometry: multiPoint)
         XCTAssertEqual((multiPointFeature.geometry.value as! MultiPoint).coordinates, coordinates)
     }
     
@@ -73,8 +73,8 @@ class GeoJSONTests: XCTestCase {
             ]
         ]
         
-        let multiLineString = Geometry.MultiLineString(coordinates: .init(coordinates))
-        let multiLineStringFeature = Feature(multiLineString)
+        let multiLineString = Geometry.MultiLineString(.init(coordinates))
+        let multiLineStringFeature = Feature(geometry: multiLineString)
         XCTAssertEqual((multiLineStringFeature.geometry.value as! MultiLineString).coordinates, coordinates)
     }
     
@@ -106,8 +106,8 @@ class GeoJSONTests: XCTestCase {
             ]
         ]
         
-        let multiPolygon = Geometry.MultiPolygon(coordinates: .init(coordinates))
-        let multiPolygonFeature = Feature(multiPolygon)
+        let multiPolygon = Geometry.MultiPolygon(.init(coordinates))
+        let multiPolygonFeature = Feature(geometry: multiPolygon)
         XCTAssertEqual((multiPolygonFeature.geometry.value as! MultiPolygon).coordinates, coordinates)
     }
 }

--- a/Tests/TurfTests/GeometryCollectionTests.swift
+++ b/Tests/TurfTests/GeometryCollectionTests.swift
@@ -25,13 +25,13 @@ class GeometryCollectionTests: XCTestCase {
         XCTAssert(geometryCollectionFeature.geometry.type == .GeometryCollection)
         XCTAssert(geometryCollectionFeature.geometry.value is GeometryCollection)
         
-        guard case let .GeometryCollection(geometries) = geometryCollectionFeature.geometry else {
+        guard case let .geometryCollection(geometries) = geometryCollectionFeature.geometry else {
             XCTFail()
             return
         }
         
         XCTAssert(geometries.geometries[2].type == .MultiPolygon)
-        guard case let .MultiPolygon(decodedMultiPolygonCoordinate) = geometries.geometries[2] else {
+        guard case let .multiPolygon(decodedMultiPolygonCoordinate) = geometries.geometries[2] else {
             XCTFail()
             return
         }
@@ -59,13 +59,13 @@ class GeometryCollectionTests: XCTestCase {
         XCTAssert(geometryCollectionFeature.geometry.type == .GeometryCollection)
         XCTAssert(geometryCollectionFeature.geometry.value is GeometryCollection)
         
-        guard case let .GeometryCollection(geometries) = geometryCollectionFeature.geometry else {
+        guard case let .geometryCollection(geometries) = geometryCollectionFeature.geometry else {
             XCTFail()
             return
         }
         
         XCTAssert(geometries.geometries[2].type == .MultiPolygon)
-        guard case let .MultiPolygon(decodedMultiPolygonCoordinate) = geometries.geometries[2] else {
+        guard case let .multiPolygon(decodedMultiPolygonCoordinate) = geometries.geometries[2] else {
             XCTFail()
             return
         }

--- a/Tests/TurfTests/LineStringTests.swift
+++ b/Tests/TurfTests/LineStringTests.swift
@@ -11,7 +11,7 @@ class LineStringTests: XCTestCase {
         let geojson = try! GeoJSON.parse(Feature.self, from: data)
         
         XCTAssert(geojson.geometry.type == .LineString)
-        guard case let .LineString(lineStringCoordinates) = geojson.geometry else {
+        guard case let .lineString(lineStringCoordinates) = geojson.geometry else {
             XCTFail()
             return
         }
@@ -25,7 +25,7 @@ class LineStringTests: XCTestCase {
         
         let encodedData = try! JSONEncoder().encode(geojson)
         let decoded = try! GeoJSON.parse(Feature.self, from: encodedData)
-        guard case let .LineString(decodedLineStringCoordinates) = decoded.geometry else {
+        guard case let .lineString(decodedLineStringCoordinates) = decoded.geometry else {
             XCTFail()
             return
         }

--- a/Tests/TurfTests/MultiLineStringTests.swift
+++ b/Tests/TurfTests/MultiLineStringTests.swift
@@ -14,7 +14,7 @@ class MultiLineStringTests: XCTestCase {
         let geojson = try! GeoJSON.parse(Feature.self, from: data)
         
         XCTAssert(geojson.geometry.type == .MultiLineString)
-        guard case let .MultiLineString(multiLineStringCoordinates) = geojson.geometry else {
+        guard case let .multiLineString(multiLineStringCoordinates) = geojson.geometry else {
             XCTFail()
             return
         }
@@ -23,7 +23,7 @@ class MultiLineStringTests: XCTestCase {
         
         let encodedData = try! JSONEncoder().encode(geojson)
         let decoded = try! GeoJSON.parse(Feature.self, from: encodedData)
-        guard case let .MultiLineString(decodedMultiLineStringCoordinates) = decoded.geometry else {
+        guard case let .multiLineString(decodedMultiLineStringCoordinates) = decoded.geometry else {
             XCTFail()
             return
         }

--- a/Tests/TurfTests/MultiPointTests.swift
+++ b/Tests/TurfTests/MultiPointTests.swift
@@ -14,7 +14,7 @@ class MultiPointTests: XCTestCase {
         let geojson = try! GeoJSON.parse(Feature.self, from: data)
                 
         XCTAssert(geojson.geometry.type == .MultiPoint)
-        guard case let .MultiPoint(multipointCoordinates) = geojson.geometry else {
+        guard case let .multiPoint(multipointCoordinates) = geojson.geometry else {
             XCTFail()
             return
         }
@@ -23,7 +23,7 @@ class MultiPointTests: XCTestCase {
         
         let encodedData = try! JSONEncoder().encode(geojson)
         let decoded = try! GeoJSON.parse(Feature.self, from: encodedData)
-        guard case let .MultiPoint(decodedMultipointCoordinates) = decoded.geometry else {
+        guard case let .multiPoint(decodedMultipointCoordinates) = decoded.geometry else {
             XCTFail()
             return
         }

--- a/Tests/TurfTests/MultiPolygonTests.swift
+++ b/Tests/TurfTests/MultiPolygonTests.swift
@@ -70,8 +70,8 @@ class MultiPolygonTests: XCTestCase {
             ]
         ]
         
-        let multiPolygon = Geometry.MultiPolygon(coordinates: .init(coordinates))
-        var multiPolygonFeature = Feature(multiPolygon)
+        let multiPolygon = Geometry.MultiPolygon(.init(coordinates))
+        var multiPolygonFeature = Feature(geometry: multiPolygon)
         multiPolygonFeature.identifier = FeatureIdentifier.string("uniqueIdentifier")
         multiPolygonFeature.properties = ["some": "var"]
 

--- a/Tests/TurfTests/MultiPolygonTests.swift
+++ b/Tests/TurfTests/MultiPolygonTests.swift
@@ -17,7 +17,7 @@ class MultiPolygonTests: XCTestCase {
         let geojson = try! GeoJSON.parse(Feature.self, from: data)
         
         XCTAssert(geojson.geometry.type == .MultiPolygon)
-        guard case let .MultiPolygon(multipolygonCoordinates) = geojson.geometry else {
+        guard case let .multiPolygon(multipolygonCoordinates) = geojson.geometry else {
             XCTFail()
             return
         }
@@ -27,7 +27,7 @@ class MultiPolygonTests: XCTestCase {
         
         let encodedData = try! JSONEncoder().encode(geojson)
         let decoded = try! GeoJSON.parse(Feature.self, from: encodedData)
-        guard case let .MultiPolygon(decodedMultipolygonCoordinates) = decoded.geometry else {
+        guard case let .multiPolygon(decodedMultipolygonCoordinates) = decoded.geometry else {
             XCTFail()
             return
         }
@@ -70,7 +70,7 @@ class MultiPolygonTests: XCTestCase {
             ]
         ]
         
-        let multiPolygon = Geometry.MultiPolygon(.init(coordinates))
+        let multiPolygon = Geometry.multiPolygon(.init(coordinates))
         var multiPolygonFeature = Feature(geometry: multiPolygon)
         multiPolygonFeature.identifier = FeatureIdentifier.string("uniqueIdentifier")
         multiPolygonFeature.properties = ["some": "var"]
@@ -80,13 +80,13 @@ class MultiPolygonTests: XCTestCase {
         
         let data = try! Fixture.geojsonData(from: "multipolygon")!
         let bundledMultiPolygon = try! GeoJSON.parse(Feature.self, from: data)
-        guard case let .MultiPolygon(bundledMultipolygonCoordinates) = bundledMultiPolygon.geometry else {
+        guard case let .multiPolygon(bundledMultipolygonCoordinates) = bundledMultiPolygon.geometry else {
             XCTFail()
             return
         }
         
         XCTAssert(decodedCustomMultiPolygon.geometry.type == .MultiPolygon)
-        guard case let .MultiPolygon(decodedMultipolygonCoordinates) = decodedCustomMultiPolygon.geometry else {
+        guard case let .multiPolygon(decodedMultipolygonCoordinates) = decodedCustomMultiPolygon.geometry else {
             XCTFail()
             return
         }

--- a/Tests/TurfTests/PointTests.swift
+++ b/Tests/TurfTests/PointTests.swift
@@ -11,7 +11,7 @@ class PointTests: XCTestCase {
         let geojson = try! GeoJSON.parse(Feature.self, from: data)
         let coordinate = CLLocationCoordinate2D(latitude: 26.194876675795218, longitude: 14.765625)
 
-        guard case let .Point(point) = geojson.geometry else {
+        guard case let .point(point) = geojson.geometry else {
             XCTFail()
             return
         }

--- a/Tests/TurfTests/PolygonTests.swift
+++ b/Tests/TurfTests/PolygonTests.swift
@@ -15,7 +15,7 @@ class PolygonTests: XCTestCase {
         
         XCTAssert((geojson.identifier!.value as! Number).value! as! Double == 1.01)
         
-        guard case let .Polygon(polygon) = geojson.geometry else {
+        guard case let .polygon(polygon) = geojson.geometry else {
             XCTFail()
             return
         }
@@ -26,7 +26,7 @@ class PolygonTests: XCTestCase {
         
         let encodedData = try! JSONEncoder().encode(geojson)
         let decoded = try! GeoJSON.parse(Feature.self, from: encodedData)
-        guard case let .Polygon(decodedPolygon) = decoded.geometry else {
+        guard case let .polygon(decodedPolygon) = decoded.geometry else {
                    XCTFail()
                    return
                }


### PR DESCRIPTION
This PR makes a couple changes to make the GeoJSON interface read better in Swift:

* Moved argument labels to GeoJSON struct initializers. It was misleading to label a geometry-typed associated value as `coordinates`. Labeling the `Geometry`-typed argument to `Feature`’s initializer means less confusion as we continue to add convenience initializers.
* Lowercased the first letter of each of `Geometry`’s cases, per Swift naming conventions. (GeoJSON always capitalizes these terms, but Swift lowercases capitalized terms at the beginning of case names anyways, like `.url` and `.mapbox`.)

For example:

```swift
// Before
Feature(.Point(coordinates: Point(coordinate)))
// After
Feature(geometry: .point(Point(coordinate)))
```

Some errors have been corrected in the example code in the readme.

/cc @mapbox/navigation-ios @frederoni