### PR TITLE
Geometries coordinates mutable

### DIFF
--- a/Sources/Turf/Geometries/GeometryCollection.swift
+++ b/Sources/Turf/Geometries/GeometryCollection.swift
@@ -5,7 +5,7 @@ import CoreLocation
 
 
 public struct GeometryCollection {
-    public let geometries: [Geometry]
+    public var geometries: [Geometry]
     
     public init(geometries: [Geometry]) {
         self.geometries = geometries

--- a/Sources/Turf/Geometries/LineString.swift
+++ b/Sources/Turf/Geometries/LineString.swift
@@ -5,7 +5,7 @@ import CoreLocation
 
 
 public struct LineString: Equatable {
-    public let coordinates: [CLLocationCoordinate2D]
+    public var coordinates: [CLLocationCoordinate2D]
     
     public init(_ coordinates: [CLLocationCoordinate2D]) {
         self.coordinates = coordinates

--- a/Sources/Turf/Geometries/MultiLineString.swift
+++ b/Sources/Turf/Geometries/MultiLineString.swift
@@ -5,7 +5,7 @@ import CoreLocation
 
 
 public struct MultiLineString: Equatable {
-    public let coordinates: [[CLLocationCoordinate2D]]
+    public var coordinates: [[CLLocationCoordinate2D]]
     
     public init(_ coordinates: [[CLLocationCoordinate2D]]) {
         self.coordinates = coordinates

--- a/Sources/Turf/Geometries/MultiPoint.swift
+++ b/Sources/Turf/Geometries/MultiPoint.swift
@@ -5,7 +5,7 @@ import CoreLocation
 
 
 public struct MultiPoint: Equatable {
-    public let coordinates: [CLLocationCoordinate2D]
+    public var coordinates: [CLLocationCoordinate2D]
     
     public init(_ coordinates: [CLLocationCoordinate2D]) {
         self.coordinates = coordinates

--- a/Sources/Turf/Geometries/MultiPolygon.swift
+++ b/Sources/Turf/Geometries/MultiPolygon.swift
@@ -5,7 +5,7 @@ import CoreLocation
 
 
 public struct MultiPolygon: Equatable {
-    public let coordinates: [[[CLLocationCoordinate2D]]]
+    public var coordinates: [[[CLLocationCoordinate2D]]]
     
     public init(_ coordinates: [[[CLLocationCoordinate2D]]]) {
         self.coordinates = coordinates

--- a/Sources/Turf/Geometries/Point.swift
+++ b/Sources/Turf/Geometries/Point.swift
@@ -5,7 +5,7 @@ import CoreLocation
 
 
 public struct Point: Equatable {
-    public let coordinates: CLLocationCoordinate2D
+    public var coordinates: CLLocationCoordinate2D
     
     public init(_ coordinates: CLLocationCoordinate2D) {
         self.coordinates = coordinates

--- a/Sources/Turf/Geometries/Polygon.swift
+++ b/Sources/Turf/Geometries/Polygon.swift
@@ -5,7 +5,7 @@ import CoreLocation
 
 
 public struct Polygon: Equatable {
-    public let coordinates: [[CLLocationCoordinate2D]]
+    public var coordinates: [[CLLocationCoordinate2D]]
     
     public init(_ coordinates: [[CLLocationCoordinate2D]]) {
         self.coordinates = coordinates


### PR DESCRIPTION
Resolves #103 
Made all Geometries struct's coordinates (or geometries for `GeometryCollection`) readwrite for convenience reasons.