### PR TITLE
IndexedCoordinate distance

### DIFF
--- a/Sources/Turf/Geometries/LineString.swift
+++ b/Sources/Turf/Geometries/LineString.swift
@@ -173,13 +173,14 @@ extension LineString {
     /// Ported from https://github.com/Turfjs/turf/blob/142e137ce0c758e2825a260ab32b24db0aa19439/packages/turf-point-on-line/index.js
     
     public func closestCoordinate(to coordinate: CLLocationCoordinate2D) -> IndexedCoordinate? {
-        guard !coordinates.isEmpty else { return nil }
+        guard let startCoordinate = coordinates.first else { return nil }
         
         guard coordinates.count > 1 else {
-            return IndexedCoordinate(coordinate: coordinates.first!, index: 0, distance: coordinate.distance(to: coordinates.first!))
+            return IndexedCoordinate(coordinate: startCoordinate, index: 0, distance: coordinate.distance(to: startCoordinate))
         }
         
         var closestCoordinate: IndexedCoordinate?
+        var closestDistance: CLLocationDistance?
         
         for index in 0..<coordinates.count - 1 {
             let segment = (coordinates[index], coordinates[index + 1])
@@ -192,14 +193,23 @@ extension LineString {
             let intersectionPoint = Turf.intersection((perpendicularPoint1, perpendicularPoint2), segment)
             let intersectionDistance: CLLocationDistance? = intersectionPoint != nil ? coordinate.distance(to: intersectionPoint!) : nil
             
-            if distances.0 < closestCoordinate?.distance ?? .greatestFiniteMagnitude {
-                closestCoordinate = IndexedCoordinate(coordinate: segment.0, index: index, distance: distances.0)
+            if distances.0 < closestDistance ?? .greatestFiniteMagnitude {
+                closestCoordinate = IndexedCoordinate(coordinate: segment.0,
+                                                      index: index,
+                                                      distance: startCoordinate.distance(to: segment.0))
+                closestDistance = distances.0
             }
-            if distances.1 < closestCoordinate?.distance ?? .greatestFiniteMagnitude {
-                closestCoordinate = IndexedCoordinate(coordinate: segment.1, index: index+1, distance: distances.1)
+            if distances.1 < closestDistance ?? .greatestFiniteMagnitude {
+                closestCoordinate = IndexedCoordinate(coordinate: segment.1,
+                                                      index: index+1,
+                                                      distance: startCoordinate.distance(to: segment.1))
+                closestDistance = distances.1
             }
-            if intersectionDistance != nil && intersectionDistance! < closestCoordinate?.distance ?? .greatestFiniteMagnitude {
-                closestCoordinate = IndexedCoordinate(coordinate: intersectionPoint!, index: index, distance: intersectionDistance!)
+            if intersectionDistance != nil && intersectionDistance! < closestDistance ?? .greatestFiniteMagnitude {
+                closestCoordinate = IndexedCoordinate(coordinate: intersectionPoint!,
+                                                      index: index,
+                                                      distance: startCoordinate.distance(to: intersectionPoint!))
+                closestDistance = intersectionDistance!
             }
         }
         

--- a/Tests/TurfTests/LineStringTests.swift
+++ b/Tests/TurfTests/LineStringTests.swift
@@ -209,6 +209,29 @@ class LineStringTests: XCTestCase {
         XCTAssertEqual(closestToLong?.coordinate.latitude ?? 0, long.latitude, accuracy: 1e-5)
         XCTAssertEqual(closestToLong?.coordinate.longitude ?? 0, long.longitude, accuracy: 1e-5)
         XCTAssertEqual(closestToLong?.index, 1, "Coordinate closer to later vertex is indexed with earlier vertex")
+        
+        // turf-point-on-line - check dist and index
+        let indexLineString = LineString([
+            [0.0, 0.0],
+            [1.0, 1.0],
+            [2.0, 2.0],
+            [3.0, 3.0],
+            [4.0, 4.0],
+            [5.0, 5.0]
+            ].map {
+                CLLocationCoordinate2D(latitude: $0.first!, longitude: $0.last!)
+        })
+
+        let pointToSnap = CLLocationCoordinate2D(latitude: 2.0, longitude: 3.0)
+        let snappedIndex = indexLineString.closestCoordinate(to: pointToSnap)
+
+        XCTAssertEqual(snappedIndex?.index, 2)
+        XCTAssertEqual(snappedIndex!.coordinate.latitude, 2.50, accuracy: 1e-3)
+        XCTAssertEqual(snappedIndex!.coordinate.longitude, 2.50, accuracy: 1e-3)
+        XCTAssertGreaterThan(Double(snappedIndex!.distance),
+                             indexLineString.coordinates[2].distance(to: indexLineString.coordinates.first!))
+        XCTAssertLessThan(Double(snappedIndex!.distance),
+                          indexLineString.coordinates[3].distance(to: indexLineString.coordinates.first!))
     }
     
     func testCoordinateFromStart() {


### PR DESCRIPTION
Fixes #78 
Fixed 'closesCoordinate' method to return correct indexed coordinate distance, measured from Line's first coordinate (as promised in the [doc](https://github.com/mapbox/turf-swift/blob/1114acd2e35512586d3917b1c5f12f4d74344fb7/Sources/Turf/LineString.swift#L92-L104)).