### PR TITLE
Document plurality of Point geometry

### DIFF
--- a/Sources/Turf/Geometries/Point.swift
+++ b/Sources/Turf/Geometries/Point.swift
@@ -5,6 +5,9 @@ import CoreLocation
 
 
 public struct Point: Equatable {
+    /** Note: The pluralization of `coordinates` is defined
+     in the GeoJSON RFC, so we've kept it for consistency.
+     https://tools.ietf.org/html/rfc7946#section-1.5 */
     public var coordinates: CLLocationCoordinate2D
     
     public init(_ coordinates: CLLocationCoordinate2D) {


### PR DESCRIPTION
~Changes the initializer for `Point` so that the argument label and parameter is `coordinate` instead of `coordinates` for grammatical consistency.~ This is part of the GeoJSON specification, so I've changed this PR to just clarify that in the docs.