### PR TITLE
Rename Turf.intersection(_:_:) to intersection(_:_:)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Turf.js | Turf-swift
 [turf-helpers#radiansToDegrees](https://github.com/Turfjs/turf/tree/master/packages/turf-helpers/#radiansToDegrees) | `CLLocationDegrees.toDegrees()`
 [turf-helpers#convertLength](https://github.com/Turfjs/turf/tree/master/packages/turf-helpers#convertlength)<br>[turf-helpers#convertArea](https://github.com/Turfjs/turf/tree/master/packages/turf-helpers#convertarea) | `Measurement.converted(to:)`
 [turf-length](https://github.com/Turfjs/turf/tree/master/packages/turf-length/) | `LineString.distance(from:to:)`
-[turf-line-intersect](https://github.com/Turfjs/turf/tree/master/packages/turf-line-intersect/) | `Turf.intersection(_:_:)`
+[turf-line-intersect](https://github.com/Turfjs/turf/tree/master/packages/turf-line-intersect/) | `intersection(_:_:)`
 [turf-line-slice](https://github.com/Turfjs/turf/tree/master/packages/turf-line-slice/) | `LineString.sliced(from:to:)`
 [turf-line-slice-along](https://github.com/Turfjs/turf/tree/master/packages/turf-line-slice-along/) | `LineString.trimmed(from:distance:)`
 [turf-midpoint](https://github.com/Turfjs/turf/blob/master/packages/turf-midpoint/index.js) | `mid(_:_:)`

--- a/Sources/Turf/Geometries/LineString.swift
+++ b/Sources/Turf/Geometries/LineString.swift
@@ -190,7 +190,7 @@ extension LineString {
             let direction = segment.0.direction(to: segment.1)
             let perpendicularPoint1 = coordinate.coordinate(at: maxDistance, facing: direction + 90)
             let perpendicularPoint2 = coordinate.coordinate(at: maxDistance, facing: direction - 90)
-            let intersectionPoint = Turf.intersection((perpendicularPoint1, perpendicularPoint2), segment)
+            let intersectionPoint = intersection((perpendicularPoint1, perpendicularPoint2), segment)
             let intersectionDistance: CLLocationDistance? = intersectionPoint != nil ? coordinate.distance(to: intersectionPoint!) : nil
             
             if distances.0 < closestDistance ?? .greatestFiniteMagnitude {

--- a/Sources/Turf/Turf.swift
+++ b/Sources/Turf/Turf.swift
@@ -3,50 +3,45 @@ import Foundation
 import CoreLocation
 #endif
 
-
 let metersPerRadian: CLLocationDistance = 6_373_000.0
 // WGS84 equatorial radius as specified by the International Union of Geodesy and Geophysics
 let equatorialRadius: CLLocationDistance = 6_378_137
 
 public typealias LineSegment = (CLLocationCoordinate2D, CLLocationCoordinate2D)
 
-
-public struct Turf {
-    
-    /**
-     Returns the intersection of two line segments.
-     */
-    public static func intersection(_ line1: LineSegment, _ line2: LineSegment) -> CLLocationCoordinate2D? {
-        // Ported from https://github.com/Turfjs/turf/blob/142e137ce0c758e2825a260ab32b24db0aa19439/packages/turf-point-on-line/index.js, in turn adapted from http://jsfiddle.net/justin_c_rounds/Gd2S2/light/
-        let denominator = ((line2.1.latitude - line2.0.latitude) * (line1.1.longitude - line1.0.longitude))
-            - ((line2.1.longitude - line2.0.longitude) * (line1.1.latitude - line1.0.latitude))
-        guard denominator != 0 else {
-            return nil
-        }
-        
-        let dStartY = line1.0.latitude - line2.0.latitude
-        let dStartX = line1.0.longitude - line2.0.longitude
-        let numerator1 = (line2.1.longitude - line2.0.longitude) * dStartY - (line2.1.latitude - line2.0.latitude) * dStartX
-        let numerator2 = (line1.1.longitude - line1.0.longitude) * dStartY - (line1.1.latitude - line1.0.latitude) * dStartX
-        let a = numerator1 / denominator
-        let b = numerator2 / denominator
-        
-        /// Intersection when the lines are cast infinitely in both directions.
-        let intersection = CLLocationCoordinate2D(latitude: line1.0.latitude + a * (line1.1.latitude - line1.0.latitude),
-                                                  longitude: line1.0.longitude + a * (line1.1.longitude - line1.0.longitude))
-        
-        /// True if line 1 is finite and line 2 is infinite.
-        let intersectsWithLine1 = a > 0 && a < 1
-        /// True if line 2 is finite and line 1 is infinite.
-        let intersectsWithLine2 = b > 0 && b < 1
-        return intersectsWithLine1 && intersectsWithLine2 ? intersection : nil
+/**
+ Returns the intersection of two line segments.
+ */
+public func intersection(_ line1: LineSegment, _ line2: LineSegment) -> CLLocationCoordinate2D? {
+    // Ported from https://github.com/Turfjs/turf/blob/142e137ce0c758e2825a260ab32b24db0aa19439/packages/turf-point-on-line/index.js, in turn adapted from http://jsfiddle.net/justin_c_rounds/Gd2S2/light/
+    let denominator = ((line2.1.latitude - line2.0.latitude) * (line1.1.longitude - line1.0.longitude))
+        - ((line2.1.longitude - line2.0.longitude) * (line1.1.latitude - line1.0.latitude))
+    guard denominator != 0 else {
+        return nil
     }
+    
+    let dStartY = line1.0.latitude - line2.0.latitude
+    let dStartX = line1.0.longitude - line2.0.longitude
+    let numerator1 = (line2.1.longitude - line2.0.longitude) * dStartY - (line2.1.latitude - line2.0.latitude) * dStartX
+    let numerator2 = (line1.1.longitude - line1.0.longitude) * dStartY - (line1.1.latitude - line1.0.latitude) * dStartX
+    let a = numerator1 / denominator
+    let b = numerator2 / denominator
+    
+    /// Intersection when the lines are cast infinitely in both directions.
+    let intersection = CLLocationCoordinate2D(latitude: line1.0.latitude + a * (line1.1.latitude - line1.0.latitude),
+                                              longitude: line1.0.longitude + a * (line1.1.longitude - line1.0.longitude))
+    
+    /// True if line 1 is finite and line 2 is infinite.
+    let intersectsWithLine1 = a > 0 && a < 1
+    /// True if line 2 is finite and line 1 is infinite.
+    let intersectsWithLine2 = b > 0 && b < 1
+    return intersectsWithLine1 && intersectsWithLine2 ? intersection : nil
 }
 
 /**
  Returns the point midway between two coordinates measured in degrees
  */
-public func mid(_ coord1: CLLocationCoordinate2D, _ coord2: CLLocationCoordinate2D) -> CLLocationCoordinate2D{
+public func mid(_ coord1: CLLocationCoordinate2D, _ coord2: CLLocationCoordinate2D) -> CLLocationCoordinate2D {
     let dist = coord1.distance(to: coord2)
     let heading = coord1.direction(to: coord2)
     return coord1.coordinate(at: dist / 2, facing: heading)

--- a/Tests/TurfTests/TurfTests.swift
+++ b/Tests/TurfTests/TurfTests.swift
@@ -36,7 +36,7 @@ class TurfTests: XCTestCase {
     
     func testIntersection() {
         let coord1 = CLLocationCoordinate2D(latitude: 30, longitude: 30)
-        let a = Turf.intersection((CLLocationCoordinate2D(latitude: 20, longitude: 20), CLLocationCoordinate2D(latitude: 40, longitude: 40)), (CLLocationCoordinate2D(latitude: 20, longitude: 40), CLLocationCoordinate2D(latitude: 40, longitude: 20)))
+        let a = intersection((CLLocationCoordinate2D(latitude: 20, longitude: 20), CLLocationCoordinate2D(latitude: 40, longitude: 40)), (CLLocationCoordinate2D(latitude: 20, longitude: 40), CLLocationCoordinate2D(latitude: 40, longitude: 20)))
         XCTAssertEqual(a, coord1)
     }
     


### PR DESCRIPTION
Removed the Turf struct, which conflicted with the Turf module name.

Fixes #110.

/cc @mapbox/navigation-ios @mapbox/maps-ios @frederoni