### PR TITLE
Make CLLocationCoordinate2D members public on Linux

### DIFF
--- a/Sources/Turf/CoreLocation.swift
+++ b/Sources/Turf/CoreLocation.swift
@@ -1,8 +1,13 @@
 import Foundation
 #if os(Linux)
 public struct CLLocationCoordinate2D {
-    let latitude: Double
-    let longitude: Double
+    public let latitude: Double
+    public let longitude: Double
+    
+    public init(latitude: Double, longitude: Double) {
+        self.latitude = latitude
+        self.longitude = longitude
+    }
 }
 public typealias CLLocationDirection = Double
 public typealias CLLocationDistance = Double


### PR DESCRIPTION
Made `CLLocationCoordinate2D.latitude` and `longitude` public and added a public initializer in the Core Location compatibility shim for Linux, so that Linux clients can use this type that they have no choice but to use.

/ref https://github.com/mapbox/turf-swift/issues/119#issuecomment-722648354 raphaelmor/Polyline#69
/cc @Udumft @frederoni