### PR TITLE
Rewrite Core Location shim for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,16 +74,16 @@ Turf.js | Turf-swift
 ----|----
 [turf-along](https://github.com/Turfjs/turf/tree/master/packages/turf-along/) | `LineString.coordinateFromStart(distance:)`
 [turf-area](https://github.com/Turfjs/turf/blob/master/packages/turf-area/) | `Polygon.area`
-[turf-bearing](https://turfjs.org/docs/#bearing) | `CLLocationCoordinate2D.direction(to:)`<br>`RadianCoordinate2D.direction(to:)`
+[turf-bearing](https://turfjs.org/docs/#bearing) | `CLLocationCoordinate2D.direction(to:)`<br>`LocationCoordinate2D.direction(to:)` on Linux<br>`RadianCoordinate2D.direction(to:)`
 [turf-bezier-spline](https://github.com/Turfjs/turf/tree/master/packages/turf-bezier-spline/) | `LineString.bezier(resolution:sharpness:)`
 [turf-boolean-point-in-polygon](https://github.com/Turfjs/turf/tree/master/packages/turf-boolean-point-in-polygon) | `Polygon.contains(_:ignoreBoundary:)`
 [turf-circle](https://turfjs.org/docs/#circle) | `Polygon(center:radius:vertices:)` |
-[turf-destination](https://github.com/Turfjs/turf/tree/master/packages/turf-destination/) | `CLLocationCoordinate2D.coordinate(at:facing:)`<br>`RadianCoordinate2D.coordinate(at:facing:)`
-[turf-distance](https://github.com/Turfjs/turf/tree/master/packages/turf-distance/) | `CLLocationCoordinate2D.distance(to:)`<br>`RadianCoordinate2D.distance(to:)`
+[turf-destination](https://github.com/Turfjs/turf/tree/master/packages/turf-destination/) | `CLLocationCoordinate2D.coordinate(at:facing:)`<br>`LocationCoordinate2D.coordinate(at:facing:)` on Linux<br>`RadianCoordinate2D.coordinate(at:facing:)`
+[turf-distance](https://github.com/Turfjs/turf/tree/master/packages/turf-distance/) | `CLLocationCoordinate2D.distance(to:)`<br>`LocationCoordinate2D.distance(to:)` on Linux<br>`RadianCoordinate2D.distance(to:)`
 [turf-helpers#polygon](https://github.com/Turfjs/turf/tree/master/packages/turf-helpers/#polygon) | `Polygon(_:)`
 [turf-helpers#lineString](https://github.com/Turfjs/turf/tree/master/packages/turf-helpers/#linestring) | `LineString(_:)`
-[turf-helpers#degreesToRadians](https://github.com/Turfjs/turf/tree/master/packages/turf-helpers/#degreesToRadians) | `CLLocationDegrees.toRadians()`
-[turf-helpers#radiansToDegrees](https://github.com/Turfjs/turf/tree/master/packages/turf-helpers/#radiansToDegrees) | `CLLocationDegrees.toDegrees()`
+[turf-helpers#degreesToRadians](https://github.com/Turfjs/turf/tree/master/packages/turf-helpers/#degreesToRadians) | `CLLocationDegrees.toRadians()`<br>`LocationDegrees.toRadians()` on Linux
+[turf-helpers#radiansToDegrees](https://github.com/Turfjs/turf/tree/master/packages/turf-helpers/#radiansToDegrees) | `CLLocationDegrees.toDegrees()`<br>`LocationDegrees.toDegrees()` on Linux
 [turf-helpers#convertLength](https://github.com/Turfjs/turf/tree/master/packages/turf-helpers#convertlength)<br>[turf-helpers#convertArea](https://github.com/Turfjs/turf/tree/master/packages/turf-helpers#convertarea) | `Measurement.converted(to:)`
 [turf-length](https://github.com/Turfjs/turf/tree/master/packages/turf-length/) | `LineString.distance(from:to:)`
 [turf-line-intersect](https://github.com/Turfjs/turf/tree/master/packages/turf-line-intersect/) | `intersection(_:_:)`
@@ -93,8 +93,8 @@ Turf.js | Turf-swift
 [turf-nearest-point-on-line](https://github.com/Turfjs/turf/tree/master/packages/turf-nearest-point-on-line/) | `LineString.closestCoordinate(to:)`
 [turf-polygon-to-line](https://github.com/Turfjs/turf/tree/master/packages/turf-polygon-to-line/) | `LineString(_:)`<br>`MultiLineString(_:)`<br>`FeatureCollection(_:)`
 [turf-simplify](https://github.com/Turfjs/turf/tree/master/packages/turf-simplify) | `LineString.simplified(tolerance:highestQuality:)`
-— | `CLLocationDirection.difference(from:)`
-— | `CLLocationDirection.wrap(min:max:)`
+— | `CLLocationDirection.difference(from:)`<br>`LocationDirection.difference(from:)` on Linux
+— | `CLLocationDirection.wrap(min:max:)`<br>`LocationDirection.wrap(min:max:)` on Linux
 
 ## GeoJSON
 

--- a/Sources/Turf/BoundingBox.swift
+++ b/Sources/Turf/BoundingBox.swift
@@ -22,7 +22,7 @@ public struct BoundingBox: Codable {
         northEast = LocationCoordinate2D(latitude: maxLat, longitude: maxLon)
     }
     
-    public init(_ southWest: LocationCoordinate2D, _ northEast: LocationCoordinate2D) {
+    public init(southWest: LocationCoordinate2D, northEast: LocationCoordinate2D) {
         self.southWest = southWest
         self.northEast = northEast
     }

--- a/Sources/Turf/BoundingBox.swift
+++ b/Sources/Turf/BoundingBox.swift
@@ -5,7 +5,7 @@ import CoreLocation
 
 public struct BoundingBox: Codable {
     
-    public init?(from coordinates: [CLLocationCoordinate2D]?) {
+    public init?(from coordinates: [LocationCoordinate2D]?) {
         guard coordinates?.count ?? 0 > 0 else {
             return nil
         }
@@ -18,16 +18,16 @@ public struct BoundingBox: Codable {
                 let maxLon = max(coordinate.longitude, result.3)
                 return (minLat: minLat, maxLat: maxLat, minLon: minLon, maxLon: maxLon)
         }
-        southWest = CLLocationCoordinate2D(latitude: minLat, longitude: minLon)
-        northEast = CLLocationCoordinate2D(latitude: maxLat, longitude: maxLon)
+        southWest = LocationCoordinate2D(latitude: minLat, longitude: minLon)
+        northEast = LocationCoordinate2D(latitude: maxLat, longitude: maxLon)
     }
     
-    public init(_ southWest: CLLocationCoordinate2D, _ northEast: CLLocationCoordinate2D) {
+    public init(_ southWest: LocationCoordinate2D, _ northEast: LocationCoordinate2D) {
         self.southWest = southWest
         self.northEast = northEast
     }
     
-    public func contains(_ coordinate: CLLocationCoordinate2D, ignoreBoundary: Bool = true) -> Bool {
+    public func contains(_ coordinate: LocationCoordinate2D, ignoreBoundary: Bool = true) -> Bool {
         if ignoreBoundary {
             return southWest.latitude < coordinate.latitude
                 && northEast.latitude > coordinate.latitude
@@ -51,12 +51,12 @@ public struct BoundingBox: Codable {
     
     public init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()
-        southWest = try container.decode(CLLocationCoordinate2DCodable.self).decodedCoordinates
-        northEast = try container.decode(CLLocationCoordinate2DCodable.self).decodedCoordinates
+        southWest = try container.decode(LocationCoordinate2DCodable.self).decodedCoordinates
+        northEast = try container.decode(LocationCoordinate2DCodable.self).decodedCoordinates
     }
     
     // MARK: - Properties
     
-    public var southWest: CLLocationCoordinate2D
-    public var northEast: CLLocationCoordinate2D
+    public var southWest: LocationCoordinate2D
+    public var northEast: LocationCoordinate2D
 }

--- a/Sources/Turf/Codable.swift
+++ b/Sources/Turf/Codable.swift
@@ -180,7 +180,7 @@ extension UnkeyedEncodingContainer {
 extension Ring: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        self = Ring(coordinates: try container.decode([CLLocationCoordinate2DCodable].self).decodedCoordinates)
+        self = Ring(coordinates: try container.decode([LocationCoordinate2DCodable].self).decodedCoordinates)
     }
     
     public func encode(to encoder: Encoder) throws {

--- a/Sources/Turf/CoreLocation.swift
+++ b/Sources/Turf/CoreLocation.swift
@@ -48,12 +48,22 @@ public typealias LocationDistance = Double
 public typealias LocationDegrees = Double
 
 /**
- A geographic coordinate.
+ A geographic coordinate with its components measured in degrees.
  */
 public struct LocationCoordinate2D {
-    let latitude: LocationDegrees
-    let longitude: LocationDegrees
+    /**
+     The latitude in degrees.
+     */
+    public let latitude: LocationDegrees
     
+    /**
+     The longitude in degrees.
+     */
+    public let longitude: LocationDegrees
+    
+    /**
+     Creates a degree-based geographic coordinate.
+     */
     public init(latitude: LocationDegrees, longitude: LocationDegrees) {
         self.latitude = latitude
         self.longitude = longitude

--- a/Sources/Turf/CoreLocation.swift
+++ b/Sources/Turf/CoreLocation.swift
@@ -61,17 +61,28 @@ public struct LocationCoordinate2D {
 }
 #endif
 
-extension CLLocationDirection {
+extension LocationDirection {
     /**
      Returns a normalized number given min and max bounds.
      */
-    public func wrap(min minimumValue: CLLocationDirection, max maximumValue: CLLocationDirection) -> CLLocationDirection {
+    public func wrap(min minimumValue: LocationDirection, max maximumValue: LocationDirection) -> LocationDirection {
         let d = maximumValue - minimumValue
         return fmod((fmod((self - minimumValue), d) + d), d) + minimumValue
     }
+    
+    /**
+     Returns the smaller difference between the receiver and another direction.
+     
+     To obtain the larger difference between the two directions, subtract the
+     return value from 360°.
+     */
+    public func difference(from beta: LocationDirection) -> LocationDirection {
+        let phi = abs(beta - self).truncatingRemainder(dividingBy: 360)
+        return phi > 180 ? 360 - phi : phi
+    }
 }
 
-extension CLLocationDegrees {
+extension LocationDegrees {
     /**
      Returns the direction in radians.
      */
@@ -82,30 +93,16 @@ extension CLLocationDegrees {
     /**
      Returns the direction in degrees.
      */
-    public func toDegrees() -> CLLocationDirection {
+    public func toDegrees() -> LocationDirection {
         return self * 180.0 / .pi
     }
 }
 
-extension CLLocationDirection {
-    /**
-     Returns the smaller difference between the receiver and another direction.
-     
-     To obtain the larger difference between the two directions, subtract the
-     return value from 360°.
-     */
-    public func difference(from beta: CLLocationDirection) -> CLLocationDirection {
-        let phi = abs(beta - self).truncatingRemainder(dividingBy: 360)
-        return phi > 180 ? 360 - phi : phi
-    }
-}
-
-struct CLLocationCoordinate2DCodable: Codable {
-    var latitude: CLLocationDegrees
-    var longitude: CLLocationDegrees
-    var decodedCoordinates: CLLocationCoordinate2D {
-        return CLLocationCoordinate2D(latitude: latitude,
-                                      longitude: longitude)
+struct LocationCoordinate2DCodable: Codable {
+    var latitude: LocationDegrees
+    var longitude: LocationDegrees
+    var decodedCoordinates: LocationCoordinate2D {
+        return LocationCoordinate2D(latitude: latitude, longitude: longitude)
     }
     
     func encode(to encoder: Encoder) throws {
@@ -116,84 +113,84 @@ struct CLLocationCoordinate2DCodable: Codable {
     
     init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()
-        longitude = try container.decode(CLLocationDegrees.self)
-        latitude = try container.decode(CLLocationDegrees.self)
+        longitude = try container.decode(LocationDegrees.self)
+        latitude = try container.decode(LocationDegrees.self)
     }
     
-    init(_ coordinate: CLLocationCoordinate2D) {
+    init(_ coordinate: LocationCoordinate2D) {
         latitude = coordinate.latitude
         longitude = coordinate.longitude
     }
 }
 
-extension CLLocationCoordinate2D {
-    var codableCoordinates: CLLocationCoordinate2DCodable {
-        return CLLocationCoordinate2DCodable(self)
+extension LocationCoordinate2D {
+    var codableCoordinates: LocationCoordinate2DCodable {
+        return LocationCoordinate2DCodable(self)
     }
 }
 
-extension Array where Element == CLLocationCoordinate2DCodable {
-    var decodedCoordinates: [CLLocationCoordinate2D] {
+extension Array where Element == LocationCoordinate2DCodable {
+    var decodedCoordinates: [LocationCoordinate2D] {
         return map { $0.decodedCoordinates }
     }
 }
 
-extension Array where Element == [CLLocationCoordinate2DCodable] {
-    var decodedCoordinates: [[CLLocationCoordinate2D]] {
+extension Array where Element == [LocationCoordinate2DCodable] {
+    var decodedCoordinates: [[LocationCoordinate2D]] {
         return map { $0.decodedCoordinates }
     }
 }
 
-extension Array where Element == [[CLLocationCoordinate2DCodable]] {
-    var decodedCoordinates: [[[CLLocationCoordinate2D]]] {
+extension Array where Element == [[LocationCoordinate2DCodable]] {
+    var decodedCoordinates: [[[LocationCoordinate2D]]] {
         return map { $0.decodedCoordinates }
     }
 }
 
-extension Array where Element == CLLocationCoordinate2D {
-    var codableCoordinates: [CLLocationCoordinate2DCodable] {
+extension Array where Element == LocationCoordinate2D {
+    var codableCoordinates: [LocationCoordinate2DCodable] {
         return map { $0.codableCoordinates }
     }
 }
 
-extension Array where Element == [CLLocationCoordinate2D] {
-    var codableCoordinates: [[CLLocationCoordinate2DCodable]] {
+extension Array where Element == [LocationCoordinate2D] {
+    var codableCoordinates: [[LocationCoordinate2DCodable]] {
         return map { $0.codableCoordinates }
     }
 }
 
-extension Array where Element == [[CLLocationCoordinate2D]] {
-    var codableCoordinates: [[[CLLocationCoordinate2DCodable]]] {
+extension Array where Element == [[LocationCoordinate2D]] {
+    var codableCoordinates: [[[LocationCoordinate2DCodable]]] {
         return map { $0.codableCoordinates }
     }
 }
 
-extension CLLocationCoordinate2D: Equatable {
+extension LocationCoordinate2D: Equatable {
     
-    /// Instantiates a CLLocationCoordinate from a RadianCoordinate2D
+    /// Instantiates a LocationCoordinate2D from a RadianCoordinate2D
     public init(_ radianCoordinate: RadianCoordinate2D) {
         self.init(latitude: radianCoordinate.latitude.toDegrees(), longitude: radianCoordinate.longitude.toDegrees())
     }
     
-    public static func ==(lhs: CLLocationCoordinate2D, rhs: CLLocationCoordinate2D) -> Bool {
+    public static func ==(lhs: LocationCoordinate2D, rhs: LocationCoordinate2D) -> Bool {
         return lhs.latitude == rhs.latitude && lhs.longitude == rhs.longitude
     }
     
     /// Returns the direction from the receiver to the given coordinate.
-    public func direction(to coordinate: CLLocationCoordinate2D) -> CLLocationDirection {
+    public func direction(to coordinate: LocationCoordinate2D) -> LocationDirection {
         return RadianCoordinate2D(self).direction(to: RadianCoordinate2D(coordinate)).toDegrees()
     }
     
     /// Returns a coordinate a certain Haversine distance away in the given direction.
-    public func coordinate(at distance: CLLocationDistance, facing direction: CLLocationDirection) -> CLLocationCoordinate2D {
+    public func coordinate(at distance: LocationDistance, facing direction: LocationDirection) -> LocationCoordinate2D {
         let radianCoordinate = RadianCoordinate2D(self).coordinate(at: distance / metersPerRadian, facing: direction.toRadians())
-        return CLLocationCoordinate2D(radianCoordinate)
+        return LocationCoordinate2D(radianCoordinate)
     }
     
     /**
      Returns the Haversine distance between two coordinates measured in degrees.
      */
-    public func distance(to coordinate: CLLocationCoordinate2D) -> CLLocationDistance {
+    public func distance(to coordinate: LocationCoordinate2D) -> LocationDistance {
         return RadianCoordinate2D(self).distance(to: RadianCoordinate2D(coordinate)) * metersPerRadian
     }
 }

--- a/Sources/Turf/CoreLocation.swift
+++ b/Sources/Turf/CoreLocation.swift
@@ -1,19 +1,64 @@
 import Foundation
-#if os(Linux)
-public struct CLLocationCoordinate2D {
-    public let latitude: Double
-    public let longitude: Double
+#if canImport(CoreLocation)
+import CoreLocation
+#endif
+
+#if canImport(CoreLocation)
+/**
+ An azimuth measured in degrees clockwise from true north.
+ 
+ This is a compatibility shim to keep the library’s public interface consistent between Apple and non-Apple platforms that lack Core Location. On Apple platforms, you can use `CLLocationDirection` anywhere you see this type.
+ */
+public typealias LocationDirection = CLLocationDirection
+
+/**
+ A distance in meters.
+ 
+ This is a compatibility shim to keep the library’s public interface consistent between Apple and non-Apple platforms that lack Core Location. On Apple platforms, you can use `CLLocationDistance` anywhere you see this type.
+ */
+public typealias LocationDistance = CLLocationDistance
+
+/**
+ A latitude or longitude in degrees.
+ 
+ This is a compatibility shim to keep the library’s public interface consistent between Apple and non-Apple platforms that lack Core Location. On Apple platforms, you can use `CLLocationDegrees` anywhere you see this type.
+ */
+public typealias LocationDegrees = CLLocationDegrees
+
+/**
+ A geographic coordinate.
+ 
+ This is a compatibility shim to keep the library’s public interface consistent between Apple and non-Apple platforms that lack Core Location. On Apple platforms, you can use `CLLocationCoordinate2D` anywhere you see this type.
+ */
+public typealias LocationCoordinate2D = CLLocationCoordinate2D
+#else
+/**
+ An azimuth measured in degrees clockwise from true north.
+ */
+public typealias LocationDirection = Double
+
+/**
+ A distance in meters.
+ */
+public typealias LocationDistance = Double
+
+/**
+ A latitude or longitude in degrees.
+ */
+public typealias LocationDegrees = Double
+
+/**
+ A geographic coordinate.
+ */
+public struct LocationCoordinate2D {
+    let latitude: LocationDegrees
+    let longitude: LocationDegrees
     
-    public init(latitude: Double, longitude: Double) {
+    public init(latitude: LocationDegrees, longitude: LocationDegrees) {
         self.latitude = latitude
         self.longitude = longitude
     }
 }
-public typealias CLLocationDirection = Double
-public typealias CLLocationDistance = Double
-public typealias CLLocationDegrees = Double
-#else
-import CoreLocation
 #endif
 
 extension CLLocationDirection {

--- a/Sources/Turf/Geometries/LineString.swift
+++ b/Sources/Turf/Geometries/LineString.swift
@@ -5,9 +5,9 @@ import CoreLocation
 
 
 public struct LineString: Equatable {
-    public var coordinates: [CLLocationCoordinate2D]
+    public var coordinates: [LocationCoordinate2D]
     
-    public init(_ coordinates: [CLLocationCoordinate2D]) {
+    public init(_ coordinates: [LocationCoordinate2D]) {
         self.coordinates = coordinates
     }
     
@@ -34,15 +34,15 @@ extension LineString {
     }
     
     /// Returns a `.LineString` along a `.LineString` within a distance from a coordinate.
-    public func trimmed(from coordinate: CLLocationCoordinate2D, distance: CLLocationDistance) -> LineString? {
+    public func trimmed(from coordinate: LocationCoordinate2D, distance: LocationDistance) -> LineString? {
         let startVertex = closestCoordinate(to: coordinate)
         guard startVertex != nil && distance != 0 else {
             return nil
         }
         
-        var vertices: [CLLocationCoordinate2D] = [startVertex!.coordinate]
-        var cumulativeDistance: CLLocationDistance = 0
-        let addVertex = { (vertex: CLLocationCoordinate2D) -> Bool in
+        var vertices: [LocationCoordinate2D] = [startVertex!.coordinate]
+        var cumulativeDistance: LocationDistance = 0
+        let addVertex = { (vertex: LocationCoordinate2D) -> Bool in
             let lastVertex = vertices.last!
             let incrementalDistance = lastVertex.distance(to: vertex)
             if cumulativeDistance + incrementalDistance <= abs(distance) {
@@ -81,23 +81,23 @@ extension LineString {
     /// of the polyline.
     public struct IndexedCoordinate {
         /// The coordinate
-        public let coordinate: Array<CLLocationCoordinate2D>.Element
+        public let coordinate: Array<LocationCoordinate2D>.Element
         /// The index of the coordinate
-        public let index: Array<CLLocationCoordinate2D>.Index
+        public let index: Array<LocationCoordinate2D>.Index
         /// The coordinate’s distance from the start of the polyline
-        public let distance: CLLocationDistance
+        public let distance: LocationDistance
     }
     
     /// Returns a coordinate along a `.LineString` at a certain distance from the start of the polyline.
-    public func coordinateFromStart(distance: CLLocationDistance) -> CLLocationCoordinate2D? {
+    public func coordinateFromStart(distance: LocationDistance) -> LocationCoordinate2D? {
         return indexedCoordinateFromStart(distance: distance)?.coordinate
     }
     
     /// Returns an indexed coordinate along a `.LineString` at a certain distance from the start of the polyline.
     ///
     /// Ported from https://github.com/Turfjs/turf/blob/142e137ce0c758e2825a260ab32b24db0aa19439/packages/turf-along/index.js
-    public func indexedCoordinateFromStart(distance: CLLocationDistance) -> IndexedCoordinate? {
-        var traveled: CLLocationDistance = 0
+    public func indexedCoordinateFromStart(distance: LocationDistance) -> IndexedCoordinate? {
+        var traveled: LocationDistance = 0
         
         guard let firstCoordinate = coordinates.first else {
             return nil
@@ -132,7 +132,7 @@ extension LineString {
     /// Returns the distance along a slice of a `.LineString` with the given endpoints.
     ///
     /// Ported from https://github.com/Turfjs/turf/blob/142e137ce0c758e2825a260ab32b24db0aa19439/packages/turf-line-slice/index.js
-    public func distance(from start: CLLocationCoordinate2D? = nil, to end: CLLocationCoordinate2D? = nil) -> CLLocationDistance? {
+    public func distance(from start: LocationCoordinate2D? = nil, to end: LocationCoordinate2D? = nil) -> LocationDistance? {
         guard !coordinates.isEmpty else { return nil }
         
         guard let slicedCoordinates = sliced(from: start, to: end)?.coordinates else {
@@ -146,7 +146,7 @@ extension LineString {
     /// Returns a subset of the `.LineString` between given coordinates.
     ///
     /// Ported from https://github.com/Turfjs/turf/blob/142e137ce0c758e2825a260ab32b24db0aa19439/packages/turf-line-slice/index.js
-    public func sliced(from start: CLLocationCoordinate2D? = nil, to end: CLLocationCoordinate2D? = nil) -> LineString? {
+    public func sliced(from start: LocationCoordinate2D? = nil, to end: LocationCoordinate2D? = nil) -> LineString? {
         guard !coordinates.isEmpty else { return nil }
                 
         let startVertex = (start != nil ? closestCoordinate(to: start!) : nil) ?? IndexedCoordinate(coordinate: coordinates.first!, index: 0, distance: 0)
@@ -172,7 +172,7 @@ extension LineString {
     ///
     /// Ported from https://github.com/Turfjs/turf/blob/142e137ce0c758e2825a260ab32b24db0aa19439/packages/turf-point-on-line/index.js
     
-    public func closestCoordinate(to coordinate: CLLocationCoordinate2D) -> IndexedCoordinate? {
+    public func closestCoordinate(to coordinate: LocationCoordinate2D) -> IndexedCoordinate? {
         guard let startCoordinate = coordinates.first else { return nil }
         
         guard coordinates.count > 1 else {
@@ -180,7 +180,7 @@ extension LineString {
         }
         
         var closestCoordinate: IndexedCoordinate?
-        var closestDistance: CLLocationDistance?
+        var closestDistance: LocationDistance?
         
         for index in 0..<coordinates.count - 1 {
             let segment = (coordinates[index], coordinates[index + 1])
@@ -191,7 +191,7 @@ extension LineString {
             let perpendicularPoint1 = coordinate.coordinate(at: maxDistance, facing: direction + 90)
             let perpendicularPoint2 = coordinate.coordinate(at: maxDistance, facing: direction - 90)
             let intersectionPoint = intersection((perpendicularPoint1, perpendicularPoint2), segment)
-            let intersectionDistance: CLLocationDistance? = intersectionPoint != nil ? coordinate.distance(to: intersectionPoint!) : nil
+            let intersectionDistance: LocationDistance? = intersectionPoint != nil ? coordinate.distance(to: intersectionPoint!) : nil
             
             if distances.0 < closestDistance ?? .greatestFiniteMagnitude {
                 closestCoordinate = IndexedCoordinate(coordinate: segment.0,
@@ -216,7 +216,7 @@ extension LineString {
         return closestCoordinate
     }
 
-    private func squareDistance(from origin: CLLocationCoordinate2D, to destination: CLLocationCoordinate2D) -> Double {
+    private func squareDistance(from origin: LocationCoordinate2D, to destination: LocationCoordinate2D) -> Double {
         let dx = origin.longitude - destination.longitude
         let dy = origin.latitude - destination.latitude
         return dx * dx + dy * dy
@@ -245,7 +245,7 @@ extension LineString {
         coordinates = newCoordinates
     }
 
-    private func squareSegmentDistance(_ coordinate: CLLocationCoordinate2D, segmentStart: CLLocationCoordinate2D, segmentEnd: CLLocationCoordinate2D) -> CLLocationDistance {
+    private func squareSegmentDistance(_ coordinate: LocationCoordinate2D, segmentStart: LocationCoordinate2D, segmentEnd: LocationCoordinate2D) -> LocationDistance {
 
         var x = segmentStart.latitude
         var y = segmentStart.longitude
@@ -269,7 +269,7 @@ extension LineString {
         return dx * dx + dy * dy
     }
 
-    private func simplifyDouglasPeuckerStep(_ coordinates: [CLLocationCoordinate2D], first: Int, last: Int, tolerance: Double, simplified: inout [CLLocationCoordinate2D]) {
+    private func simplifyDouglasPeuckerStep(_ coordinates: [LocationCoordinate2D], first: Int, last: Int, tolerance: Double, simplified: inout [LocationCoordinate2D]) {
 
         var maxSquareDistance = tolerance
         var index = 0
@@ -294,7 +294,7 @@ extension LineString {
         }
     }
 
-    private func simplifyDouglasPeucker(_ coordinates: [CLLocationCoordinate2D], tolerance: Double) -> [CLLocationCoordinate2D] {
+    private func simplifyDouglasPeucker(_ coordinates: [LocationCoordinate2D], tolerance: Double) -> [LocationCoordinate2D] {
         if coordinates.count <= 2 {
             return coordinates
         }

--- a/Sources/Turf/Geometries/MultiLineString.swift
+++ b/Sources/Turf/Geometries/MultiLineString.swift
@@ -5,9 +5,9 @@ import CoreLocation
 
 
 public struct MultiLineString: Equatable {
-    public var coordinates: [[CLLocationCoordinate2D]]
+    public var coordinates: [[LocationCoordinate2D]]
     
-    public init(_ coordinates: [[CLLocationCoordinate2D]]) {
+    public init(_ coordinates: [[LocationCoordinate2D]]) {
         self.coordinates = coordinates
     }
     

--- a/Sources/Turf/Geometries/MultiPoint.swift
+++ b/Sources/Turf/Geometries/MultiPoint.swift
@@ -5,9 +5,9 @@ import CoreLocation
 
 
 public struct MultiPoint: Equatable {
-    public var coordinates: [CLLocationCoordinate2D]
+    public var coordinates: [LocationCoordinate2D]
     
-    public init(_ coordinates: [CLLocationCoordinate2D]) {
+    public init(_ coordinates: [LocationCoordinate2D]) {
         self.coordinates = coordinates
     }
 }

--- a/Sources/Turf/Geometries/MultiPolygon.swift
+++ b/Sources/Turf/Geometries/MultiPolygon.swift
@@ -5,14 +5,14 @@ import CoreLocation
 
 
 public struct MultiPolygon: Equatable {
-    public var coordinates: [[[CLLocationCoordinate2D]]]
+    public var coordinates: [[[LocationCoordinate2D]]]
     
-    public init(_ coordinates: [[[CLLocationCoordinate2D]]]) {
+    public init(_ coordinates: [[[LocationCoordinate2D]]]) {
         self.coordinates = coordinates
     }
     
     public init(_ polygons: [Polygon]) {
-        self.coordinates = polygons.map { (polygon) -> [[CLLocationCoordinate2D]] in
+        self.coordinates = polygons.map { (polygon) -> [[LocationCoordinate2D]] in
             return polygon.coordinates
         }
     }
@@ -33,7 +33,7 @@ extension MultiPolygon {
      *
      * Calls contains function for each contained polygon
      */
-    public func contains(_ coordinate: CLLocationCoordinate2D, ignoreBoundary: Bool = false) -> Bool {
+    public func contains(_ coordinate: LocationCoordinate2D, ignoreBoundary: Bool = false) -> Bool {
         return polygons.contains {
             $0.contains(coordinate, ignoreBoundary: ignoreBoundary)
         }

--- a/Sources/Turf/Geometries/Point.swift
+++ b/Sources/Turf/Geometries/Point.swift
@@ -8,9 +8,9 @@ public struct Point: Equatable {
     /** Note: The pluralization of `coordinates` is defined
      in the GeoJSON RFC, so we've kept it for consistency.
      https://tools.ietf.org/html/rfc7946#section-1.5 */
-    public var coordinates: CLLocationCoordinate2D
+    public var coordinates: LocationCoordinate2D
     
-    public init(_ coordinates: CLLocationCoordinate2D) {
+    public init(_ coordinates: LocationCoordinate2D) {
         self.coordinates = coordinates
     }
 }

--- a/Sources/Turf/Geometries/Polygon.swift
+++ b/Sources/Turf/Geometries/Polygon.swift
@@ -5,9 +5,9 @@ import CoreLocation
 
 
 public struct Polygon: Equatable {
-    public var coordinates: [[CLLocationCoordinate2D]]
+    public var coordinates: [[LocationCoordinate2D]]
     
-    public init(_ coordinates: [[CLLocationCoordinate2D]]) {
+    public init(_ coordinates: [[LocationCoordinate2D]]) {
         self.coordinates = coordinates
     }
     
@@ -25,12 +25,12 @@ public struct Polygon: Equatable {
                            The recommended amount is 64.
      - Returns: A polygon shape which approximates a circle.
      */
-    public init(center: CLLocationCoordinate2D, radius: CLLocationDistance, vertices: Int) {
+    public init(center: LocationCoordinate2D, radius: LocationDistance, vertices: Int) {
         // The first and last coordinates in a polygon must be identical,
         // which is why we're using the inclusive range operator in this case.
         // Ported from https://github.com/Turfjs/turf/blob/17002ccd57e04e84ddb38d7e3ac8ede35b019c58/packages/turf-circle/index.ts
-        let coordinates = (0...vertices).map { ( step ) -> CLLocationCoordinate2D in
-            let bearing = fabs(CLLocationDirection(step * -360 / vertices))
+        let coordinates = (0...vertices).map { ( step ) -> LocationCoordinate2D in
+            let bearing = fabs(LocationDirection(step * -360 / vertices))
             return center.coordinate(at: radius, facing: bearing)
         }
 
@@ -65,7 +65,7 @@ extension Polygon {
     /// lies on the boundary line of the polygon or its interior rings.
     ///
     ///Ported from: https://github.com/Turfjs/turf/blob/e53677b0931da9e38bb947da448ee7404adc369d/packages/turf-boolean-point-in-polygon/index.ts#L31-L75
-    public func contains(_ coordinate: CLLocationCoordinate2D, ignoreBoundary: Bool = false) -> Bool {
+    public func contains(_ coordinate: LocationCoordinate2D, ignoreBoundary: Bool = false) -> Bool {
         guard outerRing.contains(coordinate, ignoreBoundary: ignoreBoundary) else {
             return false
         }

--- a/Sources/Turf/Geometry.swift
+++ b/Sources/Turf/Geometry.swift
@@ -76,22 +76,22 @@ extension Geometry: Codable {
             
             switch type {
             case .Point:
-                let coordinates = try container.decode(CLLocationCoordinate2DCodable.self, forKey: .coordinates).decodedCoordinates
+                let coordinates = try container.decode(LocationCoordinate2DCodable.self, forKey: .coordinates).decodedCoordinates
                 self = .point(.init(coordinates))
             case .LineString:
-                let coordinates = try container.decode([CLLocationCoordinate2DCodable].self, forKey: .coordinates).decodedCoordinates
+                let coordinates = try container.decode([LocationCoordinate2DCodable].self, forKey: .coordinates).decodedCoordinates
                 self = .lineString(.init(coordinates))
             case .Polygon:
-                let coordinates = try container.decode([[CLLocationCoordinate2DCodable]].self, forKey: .coordinates).decodedCoordinates
+                let coordinates = try container.decode([[LocationCoordinate2DCodable]].self, forKey: .coordinates).decodedCoordinates
                 self = .polygon(.init(coordinates))
             case .MultiPoint:
-                let coordinates = try container.decode([CLLocationCoordinate2DCodable].self, forKey: .coordinates).decodedCoordinates
+                let coordinates = try container.decode([LocationCoordinate2DCodable].self, forKey: .coordinates).decodedCoordinates
                 self = .multiPoint(.init(coordinates))
             case .MultiLineString:
-                let coordinates = try container.decode([[CLLocationCoordinate2DCodable]].self, forKey: .coordinates).decodedCoordinates
+                let coordinates = try container.decode([[LocationCoordinate2DCodable]].self, forKey: .coordinates).decodedCoordinates
                 self = .multiLineString(.init(coordinates))
             case .MultiPolygon:
-                let coordinates = try container.decode([[[CLLocationCoordinate2DCodable]]].self, forKey: .coordinates).decodedCoordinates
+                let coordinates = try container.decode([[[LocationCoordinate2DCodable]]].self, forKey: .coordinates).decodedCoordinates
                 self = .multiPolygon(.init(coordinates))
             case .GeometryCollection:
                 let geometries = try container.decode([Geometry].self, forKey: .geometries)

--- a/Sources/Turf/RadianCoordinate2D.swift
+++ b/Sources/Turf/RadianCoordinate2D.swift
@@ -9,7 +9,7 @@ public typealias RadianDirection = Double
 
 /**
  A `RadianCoordinate2D` is a coordinate represented in radians as opposed to
- `CLLocationCoordinate2D` which is represented in latitude and longitude.
+ `LocationCoordinate2D` which is represented in latitude and longitude.
  */
 public struct RadianCoordinate2D {
     private(set) var latitude: LocationRadians
@@ -20,7 +20,7 @@ public struct RadianCoordinate2D {
         self.longitude = longitude
     }
     
-    public init(_ degreeCoordinate: CLLocationCoordinate2D) {
+    public init(_ degreeCoordinate: LocationCoordinate2D) {
         latitude = degreeCoordinate.latitude.toRadians()
         longitude = degreeCoordinate.longitude.toRadians()
     }

--- a/Sources/Turf/Ring.swift
+++ b/Sources/Turf/Ring.swift
@@ -7,9 +7,9 @@ import CoreLocation
  Creates a `Ring` struct that represents a closed figure that is bounded by three or more straight line segments.
  */
 public struct Ring {
-    public var coordinates: [CLLocationCoordinate2D]
+    public var coordinates: [LocationCoordinate2D]
     
-    public init(coordinates: [CLLocationCoordinate2D]) {
+    public init(coordinates: [LocationCoordinate2D]) {
         self.coordinates = coordinates
     }
     
@@ -29,7 +29,7 @@ public struct Ring {
         if coordinatesCount > 2 {
             for index in 0..<coordinatesCount {
                 
-                let controlPoints: (CLLocationCoordinate2D, CLLocationCoordinate2D, CLLocationCoordinate2D)
+                let controlPoints: (LocationCoordinate2D, LocationCoordinate2D, LocationCoordinate2D)
                 
                 if index == coordinatesCount - 2 {
                     controlPoints = (coordinates[coordinatesCount - 2],
@@ -62,13 +62,13 @@ extension Ring {
      *
      * Ported from: https://github.com/Turfjs/turf/blob/e53677b0931da9e38bb947da448ee7404adc369d/packages/turf-boolean-point-in-polygon/index.ts#L77-L108
      */
-    public func contains(_ coordinate: CLLocationCoordinate2D, ignoreBoundary: Bool = false) -> Bool {
+    public func contains(_ coordinate: LocationCoordinate2D, ignoreBoundary: Bool = false) -> Bool {
         let bbox = BoundingBox(from: coordinates)
         guard bbox?.contains(coordinate, ignoreBoundary: ignoreBoundary) ?? false else {
             return false
         }
 
-        var ring: ArraySlice<CLLocationCoordinate2D>!
+        var ring: ArraySlice<LocationCoordinate2D>!
         var isInside = false
         if coordinates.first == coordinates.last {
             ring = coordinates.prefix(coordinates.count - 1)

--- a/Sources/Turf/Spline.swift
+++ b/Sources/Turf/Spline.swift
@@ -5,24 +5,24 @@ import CoreLocation
 
 
 struct SplinePoint {
-    let x: CLLocationDegrees
-    let y: CLLocationDegrees
-    let z: CLLocationDegrees
+    let x: LocationDegrees
+    let y: LocationDegrees
+    let z: LocationDegrees
     
-    init(coordinate: CLLocationCoordinate2D) {
+    init(coordinate: LocationCoordinate2D) {
         x = coordinate.longitude
         y = coordinate.latitude
         z = 0
     }
     
-    init(x: CLLocationDegrees, y: CLLocationDegrees, z: CLLocationDegrees) {
+    init(x: LocationDegrees, y: LocationDegrees, z: LocationDegrees) {
         self.x = x
         self.y = y
         self.z = z
     }
     
-    var coordinate: CLLocationCoordinate2D {
-        return CLLocationCoordinate2D(latitude: y, longitude: x)
+    var coordinate: LocationCoordinate2D {
+        return LocationCoordinate2D(latitude: y, longitude: x)
     }
 }
 

--- a/Sources/Turf/Turf.swift
+++ b/Sources/Turf/Turf.swift
@@ -3,16 +3,16 @@ import Foundation
 import CoreLocation
 #endif
 
-let metersPerRadian: CLLocationDistance = 6_373_000.0
+let metersPerRadian: LocationDistance = 6_373_000.0
 // WGS84 equatorial radius as specified by the International Union of Geodesy and Geophysics
-let equatorialRadius: CLLocationDistance = 6_378_137
+let equatorialRadius: LocationDistance = 6_378_137
 
-public typealias LineSegment = (CLLocationCoordinate2D, CLLocationCoordinate2D)
+public typealias LineSegment = (LocationCoordinate2D, LocationCoordinate2D)
 
 /**
  Returns the intersection of two line segments.
  */
-public func intersection(_ line1: LineSegment, _ line2: LineSegment) -> CLLocationCoordinate2D? {
+public func intersection(_ line1: LineSegment, _ line2: LineSegment) -> LocationCoordinate2D? {
     // Ported from https://github.com/Turfjs/turf/blob/142e137ce0c758e2825a260ab32b24db0aa19439/packages/turf-point-on-line/index.js, in turn adapted from http://jsfiddle.net/justin_c_rounds/Gd2S2/light/
     let denominator = ((line2.1.latitude - line2.0.latitude) * (line1.1.longitude - line1.0.longitude))
         - ((line2.1.longitude - line2.0.longitude) * (line1.1.latitude - line1.0.latitude))
@@ -28,8 +28,8 @@ public func intersection(_ line1: LineSegment, _ line2: LineSegment) -> CLLocati
     let b = numerator2 / denominator
     
     /// Intersection when the lines are cast infinitely in both directions.
-    let intersection = CLLocationCoordinate2D(latitude: line1.0.latitude + a * (line1.1.latitude - line1.0.latitude),
-                                              longitude: line1.0.longitude + a * (line1.1.longitude - line1.0.longitude))
+    let intersection = LocationCoordinate2D(latitude: line1.0.latitude + a * (line1.1.latitude - line1.0.latitude),
+                                            longitude: line1.0.longitude + a * (line1.1.longitude - line1.0.longitude))
     
     /// True if line 1 is finite and line 2 is infinite.
     let intersectsWithLine1 = a > 0 && a < 1
@@ -41,7 +41,7 @@ public func intersection(_ line1: LineSegment, _ line2: LineSegment) -> CLLocati
 /**
  Returns the point midway between two coordinates measured in degrees
  */
-public func mid(_ coord1: CLLocationCoordinate2D, _ coord2: CLLocationCoordinate2D) -> CLLocationCoordinate2D {
+public func mid(_ coord1: LocationCoordinate2D, _ coord2: LocationCoordinate2D) -> LocationCoordinate2D {
     let dist = coord1.distance(to: coord2)
     let heading = coord1.direction(to: coord2)
     return coord1.coordinate(at: dist / 2, facing: heading)

--- a/Tests/TurfTests/BoundingBoxTests.swift
+++ b/Tests/TurfTests/BoundingBoxTests.swift
@@ -9,49 +9,49 @@ class BoundingBoxTests: XCTestCase {
     
     func testAllPositive() {
         let coordinates = [
-            CLLocationCoordinate2D(latitude: 1, longitude: 2),
-            CLLocationCoordinate2D(latitude: 2, longitude: 1)
+            LocationCoordinate2D(latitude: 1, longitude: 2),
+            LocationCoordinate2D(latitude: 2, longitude: 1)
         ]
         let bbox = BoundingBox(from: coordinates)
-        XCTAssertEqual(bbox!.southWest, CLLocationCoordinate2D(latitude: 1, longitude: 1))
-        XCTAssertEqual(bbox!.northEast, CLLocationCoordinate2D(latitude: 2, longitude: 2))
+        XCTAssertEqual(bbox!.southWest, LocationCoordinate2D(latitude: 1, longitude: 1))
+        XCTAssertEqual(bbox!.northEast, LocationCoordinate2D(latitude: 2, longitude: 2))
     }
     
     func testAllNegative() {
         let coordinates = [
-            CLLocationCoordinate2D(latitude: -1, longitude: -2),
-            CLLocationCoordinate2D(latitude: -2, longitude: -1)
+            LocationCoordinate2D(latitude: -1, longitude: -2),
+            LocationCoordinate2D(latitude: -2, longitude: -1)
         ]
         let bbox = BoundingBox(from: coordinates)
-        XCTAssertEqual(bbox!.southWest, CLLocationCoordinate2D(latitude: -2, longitude: -2))
-        XCTAssertEqual(bbox!.northEast, CLLocationCoordinate2D(latitude: -1, longitude: -1))
+        XCTAssertEqual(bbox!.southWest, LocationCoordinate2D(latitude: -2, longitude: -2))
+        XCTAssertEqual(bbox!.northEast, LocationCoordinate2D(latitude: -1, longitude: -1))
     }
     
     func testPositiveLatNegativeLon() {
         let coordinates = [
-            CLLocationCoordinate2D(latitude: 1, longitude: -2),
-            CLLocationCoordinate2D(latitude: 2, longitude: -1)
+            LocationCoordinate2D(latitude: 1, longitude: -2),
+            LocationCoordinate2D(latitude: 2, longitude: -1)
         ]
         let bbox = BoundingBox(from: coordinates)
-        XCTAssertEqual(bbox!.southWest, CLLocationCoordinate2D(latitude: 1, longitude: -2))
-        XCTAssertEqual(bbox!.northEast, CLLocationCoordinate2D(latitude: 2, longitude: -1))
+        XCTAssertEqual(bbox!.southWest, LocationCoordinate2D(latitude: 1, longitude: -2))
+        XCTAssertEqual(bbox!.northEast, LocationCoordinate2D(latitude: 2, longitude: -1))
     }
     
     func testNegativeLatPositiveLon() {
         let coordinates = [
-            CLLocationCoordinate2D(latitude: -1, longitude: 2),
-            CLLocationCoordinate2D(latitude: -2, longitude: 1)
+            LocationCoordinate2D(latitude: -1, longitude: 2),
+            LocationCoordinate2D(latitude: -2, longitude: 1)
         ]
         let bbox = BoundingBox(from: coordinates)
-        XCTAssertEqual(bbox!.southWest, CLLocationCoordinate2D(latitude: -2, longitude: 1))
-        XCTAssertEqual(bbox!.northEast, CLLocationCoordinate2D(latitude: -1, longitude: 2))
+        XCTAssertEqual(bbox!.southWest, LocationCoordinate2D(latitude: -2, longitude: 1))
+        XCTAssertEqual(bbox!.northEast, LocationCoordinate2D(latitude: -1, longitude: 2))
     }
 
     func testContains() {
-        let coordinate = CLLocationCoordinate2D(latitude: 1, longitude: 1)
+        let coordinate = LocationCoordinate2D(latitude: 1, longitude: 1)
         let coordinates = [
-            CLLocationCoordinate2D(latitude: 0, longitude: 0),
-            CLLocationCoordinate2D(latitude: 2, longitude: 2)
+            LocationCoordinate2D(latitude: 0, longitude: 0),
+            LocationCoordinate2D(latitude: 2, longitude: 2)
         ]
         let bbox = BoundingBox(from: coordinates)
 
@@ -59,10 +59,10 @@ class BoundingBoxTests: XCTestCase {
     }
 
     func testDoesNotContain() {
-        let coordinate = CLLocationCoordinate2D(latitude: 2, longitude: 3)
+        let coordinate = LocationCoordinate2D(latitude: 2, longitude: 3)
         let coordinates = [
-            CLLocationCoordinate2D(latitude: 0, longitude: 0),
-            CLLocationCoordinate2D(latitude: 2, longitude: 2)
+            LocationCoordinate2D(latitude: 0, longitude: 0),
+            LocationCoordinate2D(latitude: 2, longitude: 2)
         ]
         let bbox = BoundingBox(from: coordinates)
 
@@ -70,10 +70,10 @@ class BoundingBoxTests: XCTestCase {
     }
 
     func testContainsAtBoundary() {
-        let coordinate = CLLocationCoordinate2D(latitude: 0, longitude: 2)
+        let coordinate = LocationCoordinate2D(latitude: 0, longitude: 2)
         let coordinates = [
-            CLLocationCoordinate2D(latitude: 0, longitude: 0),
-            CLLocationCoordinate2D(latitude: 2, longitude: 2)
+            LocationCoordinate2D(latitude: 0, longitude: 0),
+            LocationCoordinate2D(latitude: 2, longitude: 2)
         ]
         let bbox = BoundingBox(from: coordinates)
 

--- a/Tests/TurfTests/GeoJSONTests.swift
+++ b/Tests/TurfTests/GeoJSONTests.swift
@@ -8,7 +8,7 @@ import CoreLocation
 class GeoJSONTests: XCTestCase {
     
     func testPoint() {
-        let coordinate = CLLocationCoordinate2D(latitude: 10, longitude: 30)
+        let coordinate = LocationCoordinate2D(latitude: 10, longitude: 30)
         let geometry = Geometry.point(Point(coordinate))
         let pointFeature = Feature(geometry: geometry)
         
@@ -16,9 +16,9 @@ class GeoJSONTests: XCTestCase {
     }
     
     func testLineString() {
-        let coordinates = [CLLocationCoordinate2D(latitude: 10, longitude: 30),
-                           CLLocationCoordinate2D(latitude: 30, longitude: 10),
-                           CLLocationCoordinate2D(latitude: 40, longitude: 40)]
+        let coordinates = [LocationCoordinate2D(latitude: 10, longitude: 30),
+                           LocationCoordinate2D(latitude: 30, longitude: 10),
+                           LocationCoordinate2D(latitude: 40, longitude: 40)]
         
         let lineString = Geometry.lineString(.init(coordinates))
         let lineStringFeature = Feature(geometry: lineString)
@@ -28,17 +28,17 @@ class GeoJSONTests: XCTestCase {
     func testPolygon() {
         let coordinates = [
             [
-                CLLocationCoordinate2D(latitude: 10, longitude: 30),
-                CLLocationCoordinate2D(latitude: 40, longitude: 40),
-                CLLocationCoordinate2D(latitude: 40, longitude: 20),
-                CLLocationCoordinate2D(latitude: 20, longitude: 10),
-                CLLocationCoordinate2D(latitude: 10, longitude: 30)
+                LocationCoordinate2D(latitude: 10, longitude: 30),
+                LocationCoordinate2D(latitude: 40, longitude: 40),
+                LocationCoordinate2D(latitude: 40, longitude: 20),
+                LocationCoordinate2D(latitude: 20, longitude: 10),
+                LocationCoordinate2D(latitude: 10, longitude: 30)
             ],
             [
-                CLLocationCoordinate2D(latitude: 30, longitude: 20),
-                CLLocationCoordinate2D(latitude: 35, longitude: 35),
-                CLLocationCoordinate2D(latitude: 20, longitude: 30),
-                CLLocationCoordinate2D(latitude: 30, longitude: 20)
+                LocationCoordinate2D(latitude: 30, longitude: 20),
+                LocationCoordinate2D(latitude: 35, longitude: 35),
+                LocationCoordinate2D(latitude: 20, longitude: 30),
+                LocationCoordinate2D(latitude: 30, longitude: 20)
             ]
         ]
         
@@ -48,10 +48,10 @@ class GeoJSONTests: XCTestCase {
     }
     
     func testMultiPoint() {
-        let coordinates = [CLLocationCoordinate2D(latitude: 40, longitude: 10),
-                           CLLocationCoordinate2D(latitude: 30, longitude: 40),
-                           CLLocationCoordinate2D(latitude: 20, longitude: 20),
-                           CLLocationCoordinate2D(latitude: 10, longitude: 30)]
+        let coordinates = [LocationCoordinate2D(latitude: 40, longitude: 10),
+                           LocationCoordinate2D(latitude: 30, longitude: 40),
+                           LocationCoordinate2D(latitude: 20, longitude: 20),
+                           LocationCoordinate2D(latitude: 10, longitude: 30)]
         
         let multiPoint = Geometry.multiPoint(.init(coordinates))
         let multiPointFeature = Feature(geometry: multiPoint)
@@ -61,15 +61,15 @@ class GeoJSONTests: XCTestCase {
     func testMultiLineString() {
         let coordinates = [
             [
-                CLLocationCoordinate2D(latitude: 10, longitude: 10),
-                CLLocationCoordinate2D(latitude: 20, longitude: 20),
-                CLLocationCoordinate2D(latitude: 40, longitude: 10)
+                LocationCoordinate2D(latitude: 10, longitude: 10),
+                LocationCoordinate2D(latitude: 20, longitude: 20),
+                LocationCoordinate2D(latitude: 40, longitude: 10)
             ],
             [
-                CLLocationCoordinate2D(latitude: 40, longitude: 40),
-                CLLocationCoordinate2D(latitude: 30, longitude: 30),
-                CLLocationCoordinate2D(latitude: 20, longitude: 40),
-                CLLocationCoordinate2D(latitude: 10, longitude: 30)
+                LocationCoordinate2D(latitude: 40, longitude: 40),
+                LocationCoordinate2D(latitude: 30, longitude: 30),
+                LocationCoordinate2D(latitude: 20, longitude: 40),
+                LocationCoordinate2D(latitude: 10, longitude: 30)
             ]
         ]
         
@@ -82,26 +82,26 @@ class GeoJSONTests: XCTestCase {
         let coordinates = [
             [
                 [
-                    CLLocationCoordinate2D(latitude: 40, longitude: 40),
-                    CLLocationCoordinate2D(latitude: 45, longitude: 20),
-                    CLLocationCoordinate2D(latitude: 45, longitude: 30),
-                    CLLocationCoordinate2D(latitude: 40, longitude: 40)
+                    LocationCoordinate2D(latitude: 40, longitude: 40),
+                    LocationCoordinate2D(latitude: 45, longitude: 20),
+                    LocationCoordinate2D(latitude: 45, longitude: 30),
+                    LocationCoordinate2D(latitude: 40, longitude: 40)
                 ]
             ],
             [
                 [
-                    CLLocationCoordinate2D(latitude: 35, longitude: 20),
-                    CLLocationCoordinate2D(latitude: 30, longitude: 10),
-                    CLLocationCoordinate2D(latitude: 10, longitude: 10),
-                    CLLocationCoordinate2D(latitude: 5, longitude: 30),
-                    CLLocationCoordinate2D(latitude: 20, longitude: 45),
-                    CLLocationCoordinate2D(latitude: 35, longitude: 20)
+                    LocationCoordinate2D(latitude: 35, longitude: 20),
+                    LocationCoordinate2D(latitude: 30, longitude: 10),
+                    LocationCoordinate2D(latitude: 10, longitude: 10),
+                    LocationCoordinate2D(latitude: 5, longitude: 30),
+                    LocationCoordinate2D(latitude: 20, longitude: 45),
+                    LocationCoordinate2D(latitude: 35, longitude: 20)
                 ],
                 [
-                    CLLocationCoordinate2D(latitude: 20, longitude: 30),
-                    CLLocationCoordinate2D(latitude: 15, longitude: 20),
-                    CLLocationCoordinate2D(latitude: 25, longitude: 25),
-                    CLLocationCoordinate2D(latitude: 20, longitude: 30)
+                    LocationCoordinate2D(latitude: 20, longitude: 30),
+                    LocationCoordinate2D(latitude: 15, longitude: 20),
+                    LocationCoordinate2D(latitude: 25, longitude: 25),
+                    LocationCoordinate2D(latitude: 20, longitude: 30)
                 ]
             ]
         ]

--- a/Tests/TurfTests/GeometryCollectionTests.swift
+++ b/Tests/TurfTests/GeometryCollectionTests.swift
@@ -9,7 +9,7 @@ class GeometryCollectionTests: XCTestCase {
     func testGeometryCollectionFeatureDeserialization() {
         // Arrange
         let data = try! Fixture.geojsonData(from: "geometry-collection")!
-        let multiPolygonCoordinate = CLLocationCoordinate2D(latitude: 8.5, longitude: 1)
+        let multiPolygonCoordinate = LocationCoordinate2D(latitude: 8.5, longitude: 1)
         
         // Act
         let geoJSON = try! GeoJSON.parse(data)
@@ -40,7 +40,7 @@ class GeometryCollectionTests: XCTestCase {
     
     func testGeometryCollectionFeatureSerialization() {
         // Arrange
-        let multiPolygonCoordinate = CLLocationCoordinate2D(latitude: 8.5, longitude: 1)
+        let multiPolygonCoordinate = LocationCoordinate2D(latitude: 8.5, longitude: 1)
         let data = try! Fixture.geojsonData(from: "geometry-collection")!
         let geoJSON = try! GeoJSON.parse(data)
         

--- a/Tests/TurfTests/LineStringTests.swift
+++ b/Tests/TurfTests/LineStringTests.swift
@@ -17,8 +17,8 @@ class LineStringTests: XCTestCase {
         }
         
         XCTAssert(lineStringCoordinates.coordinates.count == 6)
-        let first = CLLocationCoordinate2D(latitude: 0, longitude: 0)
-        let last = CLLocationCoordinate2D(latitude: 10, longitude: 0)
+        let first = LocationCoordinate2D(latitude: 0, longitude: 0)
+        let last = LocationCoordinate2D(latitude: 10, longitude: 0)
         XCTAssert(lineStringCoordinates.coordinates.first == first)
         XCTAssert(lineStringCoordinates.coordinates.last == last)
         XCTAssert(geojson.identifier!.value as! String == "1")
@@ -39,24 +39,24 @@ class LineStringTests: XCTestCase {
         
         // turf-point-on-line - first point
         var line = [
-            CLLocationCoordinate2D(latitude: 37.72003306385638, longitude: -122.45717525482178),
-            CLLocationCoordinate2D(latitude: 37.718242366859215, longitude: -122.45717525482178),
-            ]
-        let point = CLLocationCoordinate2D(latitude: 37.72003306385638, longitude: -122.45717525482178)
+            LocationCoordinate2D(latitude: 37.72003306385638, longitude: -122.45717525482178),
+            LocationCoordinate2D(latitude: 37.718242366859215, longitude: -122.45717525482178),
+        ]
+        let point = LocationCoordinate2D(latitude: 37.72003306385638, longitude: -122.45717525482178)
         var snapped = LineString(line).closestCoordinate(to: point)
         XCTAssertEqual(point, snapped?.coordinate, "point on start should not move")
         
         // turf-point-on-line - points behind first point
         line = [
-            CLLocationCoordinate2D(latitude: 37.72003306385638, longitude: -122.45717525482178),
-            CLLocationCoordinate2D(latitude: 37.718242366859215, longitude: -122.45717525482178),
+            LocationCoordinate2D(latitude: 37.72003306385638, longitude: -122.45717525482178),
+            LocationCoordinate2D(latitude: 37.718242366859215, longitude: -122.45717525482178),
         ]
         var points = [
-            CLLocationCoordinate2D(latitude: 37.72009306385638, longitude: -122.45717525482178),
-            CLLocationCoordinate2D(latitude: 37.82009306385638, longitude: -122.45717525482178),
-            CLLocationCoordinate2D(latitude: 37.72009306385638, longitude: -122.45716525482178),
-            CLLocationCoordinate2D(latitude: 37.72009306385638, longitude: -122.45516525482178),
-            ]
+            LocationCoordinate2D(latitude: 37.72009306385638, longitude: -122.45717525482178),
+            LocationCoordinate2D(latitude: 37.82009306385638, longitude: -122.45717525482178),
+            LocationCoordinate2D(latitude: 37.72009306385638, longitude: -122.45716525482178),
+            LocationCoordinate2D(latitude: 37.72009306385638, longitude: -122.45516525482178),
+        ]
         for point in points {
             snapped = LineString(line).closestCoordinate(to: point)
             XCTAssertEqual(line.first, snapped?.coordinate, "point behind start should move to first vertex")
@@ -64,15 +64,15 @@ class LineStringTests: XCTestCase {
         
         // turf-point-on-line - points in front of last point
         line = [
-            CLLocationCoordinate2D(latitude: 37.72125936929241, longitude: -122.45616137981413),
-            CLLocationCoordinate2D(latitude: 37.72003306385638, longitude: -122.45717525482178),
-            CLLocationCoordinate2D(latitude: 37.718242366859215, longitude: -122.45717525482178),
+            LocationCoordinate2D(latitude: 37.72125936929241, longitude: -122.45616137981413),
+            LocationCoordinate2D(latitude: 37.72003306385638, longitude: -122.45717525482178),
+            LocationCoordinate2D(latitude: 37.718242366859215, longitude: -122.45717525482178),
         ]
         points = [
-            CLLocationCoordinate2D(latitude: 37.71814052497085, longitude: -122.45696067810057),
-            CLLocationCoordinate2D(latitude: 37.71813203814049, longitude: -122.4573630094528),
-            CLLocationCoordinate2D(latitude: 37.71797927502795, longitude: -122.45730936527252),
-            CLLocationCoordinate2D(latitude: 37.71704571582896, longitude: -122.45718061923981),
+            LocationCoordinate2D(latitude: 37.71814052497085, longitude: -122.45696067810057),
+            LocationCoordinate2D(latitude: 37.71813203814049, longitude: -122.4573630094528),
+            LocationCoordinate2D(latitude: 37.71797927502795, longitude: -122.45730936527252),
+            LocationCoordinate2D(latitude: 37.71704571582896, longitude: -122.45718061923981),
         ]
         for point in points {
             snapped = LineString(line).closestCoordinate(to: point)
@@ -82,35 +82,35 @@ class LineStringTests: XCTestCase {
         // turf-point-on-line - points on joints
         let lines = [
             [
-                CLLocationCoordinate2D(latitude: 37.72125936929241, longitude: -122.45616137981413),
-                CLLocationCoordinate2D(latitude: 37.72003306385638, longitude: -122.45717525482178),
-                CLLocationCoordinate2D(latitude: 37.718242366859215, longitude: -122.45717525482178)
+                LocationCoordinate2D(latitude: 37.72125936929241, longitude: -122.45616137981413),
+                LocationCoordinate2D(latitude: 37.72003306385638, longitude: -122.45717525482178),
+                LocationCoordinate2D(latitude: 37.718242366859215, longitude: -122.45717525482178)
             ],
             [
-                CLLocationCoordinate2D(latitude: 31.728167146023935, longitude: 26.279296875),
-                CLLocationCoordinate2D(latitude: 32.69486597787505, longitude: 21.796875),
-                CLLocationCoordinate2D(latitude: 29.99300228455108, longitude: 18.80859375),
-                CLLocationCoordinate2D(latitude: 33.137551192346145, longitude: 12.919921874999998),
-                CLLocationCoordinate2D(latitude: 35.60371874069731, longitude: 10.1953125),
-                CLLocationCoordinate2D(latitude: 36.527294814546245, longitude: 4.921875),
-                CLLocationCoordinate2D(latitude: 36.527294814546245, longitude: -1.669921875),
-                CLLocationCoordinate2D(latitude: 34.74161249883172, longitude: -5.44921875),
-                CLLocationCoordinate2D(latitude: 32.99023555965106, longitude: -8.7890625)
+                LocationCoordinate2D(latitude: 31.728167146023935, longitude: 26.279296875),
+                LocationCoordinate2D(latitude: 32.69486597787505, longitude: 21.796875),
+                LocationCoordinate2D(latitude: 29.99300228455108, longitude: 18.80859375),
+                LocationCoordinate2D(latitude: 33.137551192346145, longitude: 12.919921874999998),
+                LocationCoordinate2D(latitude: 35.60371874069731, longitude: 10.1953125),
+                LocationCoordinate2D(latitude: 36.527294814546245, longitude: 4.921875),
+                LocationCoordinate2D(latitude: 36.527294814546245, longitude: -1.669921875),
+                LocationCoordinate2D(latitude: 34.74161249883172, longitude: -5.44921875),
+                LocationCoordinate2D(latitude: 32.99023555965106, longitude: -8.7890625)
             ],
             [
-                CLLocationCoordinate2D(latitude: 51.52204224896724, longitude: -0.10919809341430663),
-                CLLocationCoordinate2D(latitude: 51.521942114455435, longitude: -0.10923027992248535),
-                CLLocationCoordinate2D(latitude: 51.52186200668747, longitude: -0.10916590690612793),
-                CLLocationCoordinate2D(latitude: 51.52177522311313, longitude: -0.10904788970947266),
-                CLLocationCoordinate2D(latitude: 51.521601655468345, longitude: -0.10886549949645996),
-                CLLocationCoordinate2D(latitude: 51.52138135712038, longitude: -0.10874748229980469),
-                CLLocationCoordinate2D(latitude: 51.5206870765674, longitude: -0.10855436325073242),
-                CLLocationCoordinate2D(latitude: 51.52027984939518, longitude: -0.10843634605407713),
-                CLLocationCoordinate2D(latitude: 51.519952729849024, longitude: -0.10839343070983887),
-                CLLocationCoordinate2D(latitude: 51.51957887606202, longitude: -0.10817885398864746),
-                CLLocationCoordinate2D(latitude: 51.51928513164789, longitude: -0.10814666748046874),
-                CLLocationCoordinate2D(latitude: 51.518624199789016, longitude: -0.10789990425109863),
-                CLLocationCoordinate2D(latitude: 51.51778299991493, longitude: -0.10759949684143065)
+                LocationCoordinate2D(latitude: 51.52204224896724, longitude: -0.10919809341430663),
+                LocationCoordinate2D(latitude: 51.521942114455435, longitude: -0.10923027992248535),
+                LocationCoordinate2D(latitude: 51.52186200668747, longitude: -0.10916590690612793),
+                LocationCoordinate2D(latitude: 51.52177522311313, longitude: -0.10904788970947266),
+                LocationCoordinate2D(latitude: 51.521601655468345, longitude: -0.10886549949645996),
+                LocationCoordinate2D(latitude: 51.52138135712038, longitude: -0.10874748229980469),
+                LocationCoordinate2D(latitude: 51.5206870765674, longitude: -0.10855436325073242),
+                LocationCoordinate2D(latitude: 51.52027984939518, longitude: -0.10843634605407713),
+                LocationCoordinate2D(latitude: 51.519952729849024, longitude: -0.10839343070983887),
+                LocationCoordinate2D(latitude: 51.51957887606202, longitude: -0.10817885398864746),
+                LocationCoordinate2D(latitude: 51.51928513164789, longitude: -0.10814666748046874),
+                LocationCoordinate2D(latitude: 51.518624199789016, longitude: -0.10789990425109863),
+                LocationCoordinate2D(latitude: 51.51778299991493, longitude: -0.10759949684143065)
             ]
         ];
         for line in lines {
@@ -122,19 +122,19 @@ class LineStringTests: XCTestCase {
         
         // turf-point-on-line - points on top of line
         line = [
-            CLLocationCoordinate2D(latitude: 51.52204224896724, longitude: -0.10919809341430663),
-            CLLocationCoordinate2D(latitude: 51.521942114455435, longitude: -0.10923027992248535),
-            CLLocationCoordinate2D(latitude: 51.52186200668747, longitude: -0.10916590690612793),
-            CLLocationCoordinate2D(latitude: 51.52177522311313, longitude: -0.10904788970947266),
-            CLLocationCoordinate2D(latitude: 51.521601655468345, longitude: -0.10886549949645996),
-            CLLocationCoordinate2D(latitude: 51.52138135712038, longitude: -0.10874748229980469),
-            CLLocationCoordinate2D(latitude: 51.5206870765674, longitude: -0.10855436325073242),
-            CLLocationCoordinate2D(latitude: 51.52027984939518, longitude: -0.10843634605407713),
-            CLLocationCoordinate2D(latitude: 51.519952729849024, longitude: -0.10839343070983887),
-            CLLocationCoordinate2D(latitude: 51.51957887606202, longitude: -0.10817885398864746),
-            CLLocationCoordinate2D(latitude: 51.51928513164789, longitude: -0.10814666748046874),
-            CLLocationCoordinate2D(latitude: 51.518624199789016, longitude: -0.10789990425109863),
-            CLLocationCoordinate2D(latitude: 51.51778299991493, longitude: -0.10759949684143065),
+            LocationCoordinate2D(latitude: 51.52204224896724, longitude: -0.10919809341430663),
+            LocationCoordinate2D(latitude: 51.521942114455435, longitude: -0.10923027992248535),
+            LocationCoordinate2D(latitude: 51.52186200668747, longitude: -0.10916590690612793),
+            LocationCoordinate2D(latitude: 51.52177522311313, longitude: -0.10904788970947266),
+            LocationCoordinate2D(latitude: 51.521601655468345, longitude: -0.10886549949645996),
+            LocationCoordinate2D(latitude: 51.52138135712038, longitude: -0.10874748229980469),
+            LocationCoordinate2D(latitude: 51.5206870765674, longitude: -0.10855436325073242),
+            LocationCoordinate2D(latitude: 51.52027984939518, longitude: -0.10843634605407713),
+            LocationCoordinate2D(latitude: 51.519952729849024, longitude: -0.10839343070983887),
+            LocationCoordinate2D(latitude: 51.51957887606202, longitude: -0.10817885398864746),
+            LocationCoordinate2D(latitude: 51.51928513164789, longitude: -0.10814666748046874),
+            LocationCoordinate2D(latitude: 51.518624199789016, longitude: -0.10789990425109863),
+            LocationCoordinate2D(latitude: 51.51778299991493, longitude: -0.10759949684143065),
         ]
         let dist = LineString(line).distance()!
         let increment = dist / metersPerMile / 10
@@ -153,8 +153,8 @@ class LineStringTests: XCTestCase {
         
         // turf-point-on-line - point along line
         line = [
-            CLLocationCoordinate2D(latitude: 37.72003306385638, longitude: -122.45717525482178),
-            CLLocationCoordinate2D(latitude: 37.718242366859215, longitude: -122.45717525482178),
+            LocationCoordinate2D(latitude: 37.72003306385638, longitude: -122.45717525482178),
+            LocationCoordinate2D(latitude: 37.718242366859215, longitude: -122.45717525482178),
         ]
         let pointAlong = LineString(line).coordinateFromStart(distance: 0.019 * metersPerMile)
         XCTAssertNotNil(pointAlong)
@@ -169,14 +169,14 @@ class LineStringTests: XCTestCase {
         
         // turf-point-on-line - points on sides of lines
         line = [
-            CLLocationCoordinate2D(latitude: 37.72125936929241, longitude: -122.45616137981413),
-            CLLocationCoordinate2D(latitude: 37.718242366859215, longitude: -122.45717525482178),
+            LocationCoordinate2D(latitude: 37.72125936929241, longitude: -122.45616137981413),
+            LocationCoordinate2D(latitude: 37.718242366859215, longitude: -122.45717525482178),
         ]
         points = [
-            CLLocationCoordinate2D(latitude: 37.71881098149625, longitude: -122.45702505111694),
-            CLLocationCoordinate2D(latitude: 37.719235317933844, longitude: -122.45733618736267),
-            CLLocationCoordinate2D(latitude: 37.72027068864082, longitude: -122.45686411857605),
-            CLLocationCoordinate2D(latitude: 37.72063561093274, longitude: -122.45652079582213),
+            LocationCoordinate2D(latitude: 37.71881098149625, longitude: -122.45702505111694),
+            LocationCoordinate2D(latitude: 37.719235317933844, longitude: -122.45733618736267),
+            LocationCoordinate2D(latitude: 37.72027068864082, longitude: -122.45686411857605),
+            LocationCoordinate2D(latitude: 37.72063561093274, longitude: -122.45652079582213),
         ]
         for point in points {
             let snapped = LineString(line).closestCoordinate(to: point)
@@ -188,14 +188,14 @@ class LineStringTests: XCTestCase {
         }
         
         let lineString = LineString([
-            CLLocationCoordinate2D(latitude: 49.120689999999996, longitude: -122.65401),
-            CLLocationCoordinate2D(latitude: 49.120619999999995, longitude: -122.65352),
-            CLLocationCoordinate2D(latitude: 49.120189999999994, longitude: -122.65237),
+            LocationCoordinate2D(latitude: 49.120689999999996, longitude: -122.65401),
+            LocationCoordinate2D(latitude: 49.120619999999995, longitude: -122.65352),
+            LocationCoordinate2D(latitude: 49.120189999999994, longitude: -122.65237),
         ])
         
         // https://github.com/mapbox/turf-swift/issues/27
-        let short = CLLocationCoordinate2D(latitude: 49.120403526377203, longitude: -122.6529443631224)
-        let long = CLLocationCoordinate2D(latitude: 49.120405, longitude: -122.652945)
+        let short = LocationCoordinate2D(latitude: 49.120403526377203, longitude: -122.6529443631224)
+        let long = LocationCoordinate2D(latitude: 49.120405, longitude: -122.652945)
         XCTAssertLessThan(short.distance(to: long), 1)
         
         let closestToShort = lineString.closestCoordinate(to: short)
@@ -218,11 +218,11 @@ class LineStringTests: XCTestCase {
             [3.0, 3.0],
             [4.0, 4.0],
             [5.0, 5.0]
-            ].map {
-                CLLocationCoordinate2D(latitude: $0.first!, longitude: $0.last!)
+        ].map {
+            LocationCoordinate2D(latitude: $0.first!, longitude: $0.last!)
         })
 
-        let pointToSnap = CLLocationCoordinate2D(latitude: 2.0, longitude: 3.0)
+        let pointToSnap = LocationCoordinate2D(latitude: 2.0, longitude: 3.0)
         let snappedIndex = indexLineString.closestCoordinate(to: pointToSnap)
 
         XCTAssertEqual(snappedIndex?.index, 2)
@@ -238,7 +238,7 @@ class LineStringTests: XCTestCase {
         // Ported from https://github.com/Turfjs/turf/blob/142e137ce0c758e2825a260ab32b24db0aa19439/packages/turf-along/test.js
         
         let json = Fixture.JSONFromFileNamed(name: "dc-line")
-        let line = ((json["geometry"] as! [String: Any])["coordinates"] as! [[Double]]).map { CLLocationCoordinate2D(latitude: $0[0], longitude: $0[1]) }
+        let line = ((json["geometry"] as! [String: Any])["coordinates"] as! [[Double]]).map { LocationCoordinate2D(latitude: $0[0], longitude: $0[1]) }
         
         let pointsAlong = [
             LineString(line).coordinateFromStart(distance: 1 * metersPerMile),
@@ -258,38 +258,38 @@ class LineStringTests: XCTestCase {
     }
     
     func testDistance() {
-        let point1 = CLLocationCoordinate2D(latitude: 39.984, longitude: -75.343)
-        let point2 = CLLocationCoordinate2D(latitude: 39.123, longitude: -75.534)
+        let point1 = LocationCoordinate2D(latitude: 39.984, longitude: -75.343)
+        let point2 = LocationCoordinate2D(latitude: 39.123, longitude: -75.534)
         let line = [point1, point2]
         
         // https://github.com/Turfjs/turf/blob/142e137ce0c758e2825a260ab32b24db0aa19439/packages/turf-distance/test.js
         let a = LineString(line).distance()!
         XCTAssertEqual(a, 97_159.57803131901, accuracy: 1)
         
-        let point3 = CLLocationCoordinate2D(latitude: 20, longitude: 20)
-        let point4 = CLLocationCoordinate2D(latitude: 40, longitude: 40)
+        let point3 = LocationCoordinate2D(latitude: 20, longitude: 20)
+        let point4 = LocationCoordinate2D(latitude: 40, longitude: 40)
         let line2 = [point3, point4]
         
         let c = LineString(line2).distance()!
         XCTAssertEqual(c, 2_928_304, accuracy: 1)
         
         // Adapted from: https://gist.github.com/bsudekum/2604b72ae42b6f88aa55398b2ff0dc22
-        let d = LineString(line2).distance(from: CLLocationCoordinate2D(latitude: 30, longitude: 30), to: CLLocationCoordinate2D(latitude: 40, longitude: 40))!
+        let d = LineString(line2).distance(from: LocationCoordinate2D(latitude: 30, longitude: 30), to: LocationCoordinate2D(latitude: 40, longitude: 40))!
         XCTAssertEqual(d, 1_546_971, accuracy: 1)
         
         // https://github.com/mapbox/turf-swift/issues/27
-        let short = CLLocationCoordinate2D(latitude: 49.120403526377203, longitude: -122.6529443631224)
-        let long = CLLocationCoordinate2D(latitude: 49.120405, longitude: -122.652945)
+        let short = LocationCoordinate2D(latitude: 49.120403526377203, longitude: -122.6529443631224)
+        let long = LocationCoordinate2D(latitude: 49.120405, longitude: -122.652945)
         XCTAssertLessThan(short.distance(to: long), 1)
         
         XCTAssertEqual(0, LineString([
-            CLLocationCoordinate2D(latitude: 49.120689999999996, longitude: -122.65401),
-            CLLocationCoordinate2D(latitude: 49.120619999999995, longitude: -122.65352),
+            LocationCoordinate2D(latitude: 49.120689999999996, longitude: -122.65401),
+            LocationCoordinate2D(latitude: 49.120619999999995, longitude: -122.65352),
         ]).distance(from: short, to: long), "Distance between two coordinates past the end of the line string should be 0")
         XCTAssertEqual(short.distance(to: long), LineString([
-            CLLocationCoordinate2D(latitude: 49.120689999999996, longitude: -122.65401),
-            CLLocationCoordinate2D(latitude: 49.120619999999995, longitude: -122.65352),
-            CLLocationCoordinate2D(latitude: 49.120189999999994, longitude: -122.65237),
+            LocationCoordinate2D(latitude: 49.120689999999996, longitude: -122.65401),
+            LocationCoordinate2D(latitude: 49.120619999999995, longitude: -122.65352),
+            LocationCoordinate2D(latitude: 49.120189999999994, longitude: -122.65237),
         ]).distance(from: short, to: long)!, accuracy: 0.1, "Distance between two coordinates between the same vertices should be roughly the same as the distance between those two coordinates")
     }
     
@@ -298,19 +298,19 @@ class LineStringTests: XCTestCase {
         
         // turf-line-slice -- line1
         let line1 = [
-            CLLocationCoordinate2D(latitude: 22.466878364528448, longitude: -97.88131713867188),
-            CLLocationCoordinate2D(latitude: 22.175960091218524, longitude: -97.82089233398438),
-            CLLocationCoordinate2D(latitude: 21.8704201873689, longitude: -97.6190185546875),
-            ]
-        var start = CLLocationCoordinate2D(latitude: 22.254624939561698, longitude: -97.79617309570312)
-        var stop = CLLocationCoordinate2D(latitude: 22.057641623615734, longitude: -97.72750854492188)
+            LocationCoordinate2D(latitude: 22.466878364528448, longitude: -97.88131713867188),
+            LocationCoordinate2D(latitude: 22.175960091218524, longitude: -97.82089233398438),
+            LocationCoordinate2D(latitude: 21.8704201873689, longitude: -97.6190185546875),
+        ]
+        var start = LocationCoordinate2D(latitude: 22.254624939561698, longitude: -97.79617309570312)
+        var stop = LocationCoordinate2D(latitude: 22.057641623615734, longitude: -97.72750854492188)
         var sliced = LineString(line1).sliced(from: start, to: stop)
         var slicedCoordinates = sliced?.coordinates
         let line1Out = [
-            CLLocationCoordinate2D(latitude: 22.247393614241204, longitude: -97.83572934173804),
-            CLLocationCoordinate2D(latitude: 22.175960091218524, longitude: -97.82089233398438),
-            CLLocationCoordinate2D(latitude: 22.051208078134735, longitude: -97.7384672234217),
-            ]
+            LocationCoordinate2D(latitude: 22.247393614241204, longitude: -97.83572934173804),
+            LocationCoordinate2D(latitude: 22.175960091218524, longitude: -97.82089233398438),
+            LocationCoordinate2D(latitude: 22.051208078134735, longitude: -97.7384672234217),
+        ]
         XCTAssertEqual(line1Out.first!.latitude, 22.247393614241204, accuracy: 0.001)
         XCTAssertEqual(line1Out.first!.longitude, -97.83572934173804, accuracy: 0.001)
         
@@ -322,11 +322,11 @@ class LineStringTests: XCTestCase {
         
         // turf-line-slice -- vertical
         let vertical = [
-            CLLocationCoordinate2D(latitude: 38.70582415504791, longitude: -121.25447809696198),
-            CLLocationCoordinate2D(latitude: 38.709767459877554, longitude: -121.25449419021606),
-            ]
-        start = CLLocationCoordinate2D(latitude: 38.70582415504791, longitude: -121.25447809696198)
-        stop = CLLocationCoordinate2D(latitude: 38.70634324369764, longitude: -121.25447809696198)
+            LocationCoordinate2D(latitude: 38.70582415504791, longitude: -121.25447809696198),
+            LocationCoordinate2D(latitude: 38.709767459877554, longitude: -121.25449419021606),
+        ]
+        start = LocationCoordinate2D(latitude: 38.70582415504791, longitude: -121.25447809696198)
+        stop = LocationCoordinate2D(latitude: 38.70634324369764, longitude: -121.25447809696198)
         sliced = LineString(vertical).sliced(from: start, to: stop)
         slicedCoordinates = sliced?.coordinates
         XCTAssertEqual(slicedCoordinates?.count, 2, "no duplicated coords")
@@ -344,122 +344,126 @@ class LineStringTests: XCTestCase {
     }
 
     func testSimplify() {
-        let coordinates = [CLLocationCoordinate2D(latitude: -80.51399230957031, longitude: 28.069556808283608),
-                           CLLocationCoordinate2D(latitude: -80.51193237304688, longitude: 28.057438520876673),
-                           CLLocationCoordinate2D(latitude: -80.49819946289062, longitude: 28.05622661698537),
-                           CLLocationCoordinate2D(latitude: -80.5023193359375, longitude: 28.04471284867091),
-                           CLLocationCoordinate2D(latitude: -80.48583984375, longitude: 28.042288740362853),
-                           CLLocationCoordinate2D(latitude: -80.50575256347656, longitude: 28.028349057505775),
-                           CLLocationCoordinate2D(latitude: -80.50163269042969, longitude: 28.02168161433489),
-                           CLLocationCoordinate2D(latitude: -80.49476623535156, longitude: 28.021075462659883),
-                           CLLocationCoordinate2D(latitude: -80.48652648925781, longitude: 28.021075462659883),
-                           CLLocationCoordinate2D(latitude: -80.47691345214844, longitude: 28.021075462659883),
-                           CLLocationCoordinate2D(latitude: -80.46936035156249, longitude: 28.015619944017807),
-                           CLLocationCoordinate2D(latitude: -80.47760009765624, longitude: 28.007133032319448),
-                           CLLocationCoordinate2D(latitude: -80.49201965332031, longitude: 27.998039170620494),
-                           CLLocationCoordinate2D(latitude: -80.46730041503906, longitude: 27.962262536875905),
-                           CLLocationCoordinate2D(latitude: -80.46524047851562, longitude: 27.91980029694533),
-                           CLLocationCoordinate2D(latitude: -80.40550231933594, longitude: 27.930114089618602),
-                           CLLocationCoordinate2D(latitude: -80.39657592773438, longitude: 27.980455528671527),
-                           CLLocationCoordinate2D(latitude: -80.41305541992188, longitude: 27.982274659104082),
-                           CLLocationCoordinate2D(latitude: -80.42953491210938, longitude: 27.990763528690582),
-                           CLLocationCoordinate2D(latitude: -80.4144287109375, longitude: 28.00955793247135),
-                           CLLocationCoordinate2D(latitude: -80.3594970703125, longitude: 27.972572275562527),
-                           CLLocationCoordinate2D(latitude: -80.36224365234375, longitude: 27.948919060105453),
-                           CLLocationCoordinate2D(latitude: -80.38215637207031, longitude: 27.913732900444284),
-                           CLLocationCoordinate2D(latitude: -80.41786193847656, longitude: 27.881570017022806),
-                           CLLocationCoordinate2D(latitude: -80.40550231933594, longitude: 27.860932192608534),
-                           CLLocationCoordinate2D(latitude: -80.39382934570312, longitude: 27.85425440786446),
-                           CLLocationCoordinate2D(latitude: -80.37803649902344, longitude: 27.86336037597851),
-                           CLLocationCoordinate2D(latitude: -80.38215637207031, longitude: 27.880963078302393),
-                           CLLocationCoordinate2D(latitude: -80.36842346191405, longitude: 27.888246118437756),
-                           CLLocationCoordinate2D(latitude: -80.35743713378906, longitude: 27.882176952341734),
-                           CLLocationCoordinate2D(latitude: -80.35469055175781, longitude: 27.86882358965466),
-                           CLLocationCoordinate2D(latitude: -80.3594970703125, longitude: 27.8421119273228),
-                           CLLocationCoordinate2D(latitude: -80.37940979003906, longitude: 27.83300417483936),
-                           CLLocationCoordinate2D(latitude: -80.39932250976561, longitude: 27.82511017099003),
-                           CLLocationCoordinate2D(latitude: -80.40069580078125, longitude: 27.79352841586229),
-                           CLLocationCoordinate2D(latitude: -80.36155700683594, longitude: 27.786846483587688),
-                           CLLocationCoordinate2D(latitude: -80.35537719726562, longitude: 27.794743268514615),
-                           CLLocationCoordinate2D(latitude: -80.36705017089844, longitude: 27.800209937418252),
-                           CLLocationCoordinate2D(latitude: -80.36889553070068, longitude: 27.801918215058347),
-                           CLLocationCoordinate2D(latitude: -80.3690242767334, longitude: 27.803930152059845),
-                           CLLocationCoordinate2D(latitude: -80.36713600158691, longitude: 27.805942051806845),
-                           CLLocationCoordinate2D(latitude: -80.36584854125977, longitude: 27.805524490772143),
-                           CLLocationCoordinate2D(latitude: -80.36563396453857, longitude: 27.80465140342285),
-                           CLLocationCoordinate2D(latitude: -80.36619186401367, longitude: 27.803095012921272),
-                           CLLocationCoordinate2D(latitude: -80.36623477935791, longitude: 27.801842292177923),
-                           CLLocationCoordinate2D(latitude: -80.36524772644043, longitude: 27.80127286888392),
-                           CLLocationCoordinate2D(latitude: -80.36224365234375, longitude: 27.801158983867033),
-                           CLLocationCoordinate2D(latitude: -80.36065578460693, longitude: 27.802639479776524),
-                           CLLocationCoordinate2D(latitude: -80.36138534545898, longitude: 27.803740348273823),
-                           CLLocationCoordinate2D(latitude: -80.36220073699951, longitude: 27.804803245204976),
-                           CLLocationCoordinate2D(latitude: -80.36190032958984, longitude: 27.806625330038287),
-                           CLLocationCoordinate2D(latitude: -80.3609561920166, longitude: 27.80742248254359),
-                           CLLocationCoordinate2D(latitude: -80.35932540893555, longitude: 27.806853088493792),
-                           CLLocationCoordinate2D(latitude: -80.35889625549315, longitude: 27.806321651354835),
-                           CLLocationCoordinate2D(latitude: -80.35902500152588, longitude: 27.805448570411585),
-                           CLLocationCoordinate2D(latitude: -80.35863876342773, longitude: 27.804461600896783),
-                           CLLocationCoordinate2D(latitude: -80.35739421844482, longitude: 27.804461600896783),
-                           CLLocationCoordinate2D(latitude: -80.35700798034668, longitude: 27.805334689771293),
-                           CLLocationCoordinate2D(latitude: -80.35696506500244, longitude: 27.80673920932572),
-                           CLLocationCoordinate2D(latitude: -80.35726547241211, longitude: 27.80772615814989),
-                           CLLocationCoordinate2D(latitude: -80.35808086395264, longitude: 27.808295547623707),
-                           CLLocationCoordinate2D(latitude: -80.3585958480835, longitude: 27.80928248230861),
-                           CLLocationCoordinate2D(latitude: -80.35653591156006, longitude: 27.80943431761813),
-                           CLLocationCoordinate2D(latitude: -80.35572052001953, longitude: 27.808637179875486),
-                           CLLocationCoordinate2D(latitude: -80.3555917739868, longitude: 27.80772615814989),
-                           CLLocationCoordinate2D(latitude: -80.3555917739868, longitude: 27.806055931810487),
-                           CLLocationCoordinate2D(latitude: -80.35572052001953, longitude: 27.803778309057556),
-                           CLLocationCoordinate2D(latitude: -80.35537719726562, longitude: 27.801804330717825),
-                           CLLocationCoordinate2D(latitude: -80.3554630279541, longitude: 27.799564581098746),
-                           CLLocationCoordinate2D(latitude: -80.35670757293701, longitude: 27.799564581098746),
-                           CLLocationCoordinate2D(latitude: -80.35499095916748, longitude: 27.796831264786892),
-                           CLLocationCoordinate2D(latitude: -80.34610748291016, longitude: 27.79478123244122),
-                           CLLocationCoordinate2D(latitude: -80.34404754638672, longitude: 27.802070060660014),
-                           CLLocationCoordinate2D(latitude: -80.34748077392578, longitude: 27.804955086774896),
-                           CLLocationCoordinate2D(latitude: -80.3433609008789, longitude: 27.805790211616266),
-                           CLLocationCoordinate2D(latitude: -80.34353256225586, longitude: 27.8101555324401),
-                           CLLocationCoordinate2D(latitude: -80.33499240875244, longitude: 27.810079615315917),
-                           CLLocationCoordinate2D(latitude: -80.33383369445801, longitude: 27.805676331334084),
-                           CLLocationCoordinate2D(latitude: -80.33022880554199, longitude: 27.801652484744796),
-                           CLLocationCoordinate2D(latitude: -80.32872676849365, longitude: 27.80848534345178)]
+        let coordinates = [
+            LocationCoordinate2D(latitude: -80.51399230957031, longitude: 28.069556808283608),
+            LocationCoordinate2D(latitude: -80.51193237304688, longitude: 28.057438520876673),
+            LocationCoordinate2D(latitude: -80.49819946289062, longitude: 28.05622661698537),
+            LocationCoordinate2D(latitude: -80.5023193359375, longitude: 28.04471284867091),
+            LocationCoordinate2D(latitude: -80.48583984375, longitude: 28.042288740362853),
+            LocationCoordinate2D(latitude: -80.50575256347656, longitude: 28.028349057505775),
+            LocationCoordinate2D(latitude: -80.50163269042969, longitude: 28.02168161433489),
+            LocationCoordinate2D(latitude: -80.49476623535156, longitude: 28.021075462659883),
+            LocationCoordinate2D(latitude: -80.48652648925781, longitude: 28.021075462659883),
+            LocationCoordinate2D(latitude: -80.47691345214844, longitude: 28.021075462659883),
+            LocationCoordinate2D(latitude: -80.46936035156249, longitude: 28.015619944017807),
+            LocationCoordinate2D(latitude: -80.47760009765624, longitude: 28.007133032319448),
+            LocationCoordinate2D(latitude: -80.49201965332031, longitude: 27.998039170620494),
+            LocationCoordinate2D(latitude: -80.46730041503906, longitude: 27.962262536875905),
+            LocationCoordinate2D(latitude: -80.46524047851562, longitude: 27.91980029694533),
+            LocationCoordinate2D(latitude: -80.40550231933594, longitude: 27.930114089618602),
+            LocationCoordinate2D(latitude: -80.39657592773438, longitude: 27.980455528671527),
+            LocationCoordinate2D(latitude: -80.41305541992188, longitude: 27.982274659104082),
+            LocationCoordinate2D(latitude: -80.42953491210938, longitude: 27.990763528690582),
+            LocationCoordinate2D(latitude: -80.4144287109375, longitude: 28.00955793247135),
+            LocationCoordinate2D(latitude: -80.3594970703125, longitude: 27.972572275562527),
+            LocationCoordinate2D(latitude: -80.36224365234375, longitude: 27.948919060105453),
+            LocationCoordinate2D(latitude: -80.38215637207031, longitude: 27.913732900444284),
+            LocationCoordinate2D(latitude: -80.41786193847656, longitude: 27.881570017022806),
+            LocationCoordinate2D(latitude: -80.40550231933594, longitude: 27.860932192608534),
+            LocationCoordinate2D(latitude: -80.39382934570312, longitude: 27.85425440786446),
+            LocationCoordinate2D(latitude: -80.37803649902344, longitude: 27.86336037597851),
+            LocationCoordinate2D(latitude: -80.38215637207031, longitude: 27.880963078302393),
+            LocationCoordinate2D(latitude: -80.36842346191405, longitude: 27.888246118437756),
+            LocationCoordinate2D(latitude: -80.35743713378906, longitude: 27.882176952341734),
+            LocationCoordinate2D(latitude: -80.35469055175781, longitude: 27.86882358965466),
+            LocationCoordinate2D(latitude: -80.3594970703125, longitude: 27.8421119273228),
+            LocationCoordinate2D(latitude: -80.37940979003906, longitude: 27.83300417483936),
+            LocationCoordinate2D(latitude: -80.39932250976561, longitude: 27.82511017099003),
+            LocationCoordinate2D(latitude: -80.40069580078125, longitude: 27.79352841586229),
+            LocationCoordinate2D(latitude: -80.36155700683594, longitude: 27.786846483587688),
+            LocationCoordinate2D(latitude: -80.35537719726562, longitude: 27.794743268514615),
+            LocationCoordinate2D(latitude: -80.36705017089844, longitude: 27.800209937418252),
+            LocationCoordinate2D(latitude: -80.36889553070068, longitude: 27.801918215058347),
+            LocationCoordinate2D(latitude: -80.3690242767334, longitude: 27.803930152059845),
+            LocationCoordinate2D(latitude: -80.36713600158691, longitude: 27.805942051806845),
+            LocationCoordinate2D(latitude: -80.36584854125977, longitude: 27.805524490772143),
+            LocationCoordinate2D(latitude: -80.36563396453857, longitude: 27.80465140342285),
+            LocationCoordinate2D(latitude: -80.36619186401367, longitude: 27.803095012921272),
+            LocationCoordinate2D(latitude: -80.36623477935791, longitude: 27.801842292177923),
+            LocationCoordinate2D(latitude: -80.36524772644043, longitude: 27.80127286888392),
+            LocationCoordinate2D(latitude: -80.36224365234375, longitude: 27.801158983867033),
+            LocationCoordinate2D(latitude: -80.36065578460693, longitude: 27.802639479776524),
+            LocationCoordinate2D(latitude: -80.36138534545898, longitude: 27.803740348273823),
+            LocationCoordinate2D(latitude: -80.36220073699951, longitude: 27.804803245204976),
+            LocationCoordinate2D(latitude: -80.36190032958984, longitude: 27.806625330038287),
+            LocationCoordinate2D(latitude: -80.3609561920166, longitude: 27.80742248254359),
+            LocationCoordinate2D(latitude: -80.35932540893555, longitude: 27.806853088493792),
+            LocationCoordinate2D(latitude: -80.35889625549315, longitude: 27.806321651354835),
+            LocationCoordinate2D(latitude: -80.35902500152588, longitude: 27.805448570411585),
+            LocationCoordinate2D(latitude: -80.35863876342773, longitude: 27.804461600896783),
+            LocationCoordinate2D(latitude: -80.35739421844482, longitude: 27.804461600896783),
+            LocationCoordinate2D(latitude: -80.35700798034668, longitude: 27.805334689771293),
+            LocationCoordinate2D(latitude: -80.35696506500244, longitude: 27.80673920932572),
+            LocationCoordinate2D(latitude: -80.35726547241211, longitude: 27.80772615814989),
+            LocationCoordinate2D(latitude: -80.35808086395264, longitude: 27.808295547623707),
+            LocationCoordinate2D(latitude: -80.3585958480835, longitude: 27.80928248230861),
+            LocationCoordinate2D(latitude: -80.35653591156006, longitude: 27.80943431761813),
+            LocationCoordinate2D(latitude: -80.35572052001953, longitude: 27.808637179875486),
+            LocationCoordinate2D(latitude: -80.3555917739868, longitude: 27.80772615814989),
+            LocationCoordinate2D(latitude: -80.3555917739868, longitude: 27.806055931810487),
+            LocationCoordinate2D(latitude: -80.35572052001953, longitude: 27.803778309057556),
+            LocationCoordinate2D(latitude: -80.35537719726562, longitude: 27.801804330717825),
+            LocationCoordinate2D(latitude: -80.3554630279541, longitude: 27.799564581098746),
+            LocationCoordinate2D(latitude: -80.35670757293701, longitude: 27.799564581098746),
+            LocationCoordinate2D(latitude: -80.35499095916748, longitude: 27.796831264786892),
+            LocationCoordinate2D(latitude: -80.34610748291016, longitude: 27.79478123244122),
+            LocationCoordinate2D(latitude: -80.34404754638672, longitude: 27.802070060660014),
+            LocationCoordinate2D(latitude: -80.34748077392578, longitude: 27.804955086774896),
+            LocationCoordinate2D(latitude: -80.3433609008789, longitude: 27.805790211616266),
+            LocationCoordinate2D(latitude: -80.34353256225586, longitude: 27.8101555324401),
+            LocationCoordinate2D(latitude: -80.33499240875244, longitude: 27.810079615315917),
+            LocationCoordinate2D(latitude: -80.33383369445801, longitude: 27.805676331334084),
+            LocationCoordinate2D(latitude: -80.33022880554199, longitude: 27.801652484744796),
+            LocationCoordinate2D(latitude: -80.32872676849365, longitude: 27.80848534345178),
+        ]
 
-        let simplifiedCoordinates = [CLLocationCoordinate2D(latitude : -80.51399230957031, longitude : 28.069556808283608),
-                                     CLLocationCoordinate2D(latitude : -80.49819946289062, longitude : 28.05622661698537),
-                                     CLLocationCoordinate2D(latitude : -80.5023193359375, longitude : 28.04471284867091),
-                                     CLLocationCoordinate2D(latitude : -80.48583984375, longitude : 28.042288740362853),
-                                     CLLocationCoordinate2D(latitude : -80.50575256347656, longitude : 28.028349057505775),
-                                     CLLocationCoordinate2D(latitude : -80.49476623535156, longitude : 28.021075462659883),
-                                     CLLocationCoordinate2D(latitude : -80.47691345214844, longitude : 28.021075462659883),
-                                     CLLocationCoordinate2D(latitude : -80.49201965332031, longitude : 27.998039170620494),
-                                     CLLocationCoordinate2D(latitude : -80.46730041503906, longitude : 27.962262536875905),
-                                     CLLocationCoordinate2D(latitude : -80.46524047851562, longitude : 27.91980029694533),
-                                     CLLocationCoordinate2D(latitude : -80.40550231933594, longitude : 27.930114089618602),
-                                     CLLocationCoordinate2D(latitude : -80.39657592773438, longitude : 27.980455528671527),
-                                     CLLocationCoordinate2D(latitude : -80.41305541992188, longitude : 27.982274659104082),
-                                     CLLocationCoordinate2D(latitude : -80.42953491210938, longitude : 27.990763528690582),
-                                     CLLocationCoordinate2D(latitude : -80.4144287109375, longitude : 28.00955793247135),
-                                     CLLocationCoordinate2D(latitude : -80.3594970703125, longitude : 27.972572275562527),
-                                     CLLocationCoordinate2D(latitude : -80.38215637207031, longitude : 27.913732900444284),
-                                     CLLocationCoordinate2D(latitude : -80.41786193847656, longitude : 27.881570017022806),
-                                     CLLocationCoordinate2D(latitude : -80.39382934570312, longitude : 27.85425440786446),
-                                     CLLocationCoordinate2D(latitude : -80.37803649902344, longitude : 27.86336037597851),
-                                     CLLocationCoordinate2D(latitude : -80.38215637207031, longitude : 27.880963078302393),
-                                     CLLocationCoordinate2D(latitude : -80.36842346191405, longitude : 27.888246118437756),
-                                     CLLocationCoordinate2D(latitude : -80.35743713378906, longitude : 27.882176952341734),
-                                     CLLocationCoordinate2D(latitude : -80.3594970703125, longitude : 27.8421119273228),
-                                     CLLocationCoordinate2D(latitude : -80.37940979003906, longitude : 27.83300417483936),
-                                     CLLocationCoordinate2D(latitude : -80.39932250976561, longitude : 27.82511017099003),
-                                     CLLocationCoordinate2D(latitude : -80.40069580078125, longitude : 27.79352841586229),
-                                     CLLocationCoordinate2D(latitude : -80.36155700683594, longitude : 27.786846483587688),
-                                     CLLocationCoordinate2D(latitude : -80.35537719726562, longitude : 27.794743268514615),
-                                     CLLocationCoordinate2D(latitude : -80.36705017089844, longitude : 27.800209937418252),
-                                     CLLocationCoordinate2D(latitude : -80.35932540893555, longitude : 27.806853088493792),
-                                     CLLocationCoordinate2D(latitude : -80.35499095916748, longitude : 27.796831264786892),
-                                     CLLocationCoordinate2D(latitude : -80.34404754638672, longitude : 27.802070060660014),
-                                     CLLocationCoordinate2D(latitude : -80.33499240875244, longitude : 27.810079615315917),
-                                     CLLocationCoordinate2D(latitude : -80.32872676849365, longitude : 27.80848534345178)]
+        let simplifiedCoordinates = [
+            LocationCoordinate2D(latitude : -80.51399230957031, longitude : 28.069556808283608),
+            LocationCoordinate2D(latitude : -80.49819946289062, longitude : 28.05622661698537),
+            LocationCoordinate2D(latitude : -80.5023193359375, longitude : 28.04471284867091),
+            LocationCoordinate2D(latitude : -80.48583984375, longitude : 28.042288740362853),
+            LocationCoordinate2D(latitude : -80.50575256347656, longitude : 28.028349057505775),
+            LocationCoordinate2D(latitude : -80.49476623535156, longitude : 28.021075462659883),
+            LocationCoordinate2D(latitude : -80.47691345214844, longitude : 28.021075462659883),
+            LocationCoordinate2D(latitude : -80.49201965332031, longitude : 27.998039170620494),
+            LocationCoordinate2D(latitude : -80.46730041503906, longitude : 27.962262536875905),
+            LocationCoordinate2D(latitude : -80.46524047851562, longitude : 27.91980029694533),
+            LocationCoordinate2D(latitude : -80.40550231933594, longitude : 27.930114089618602),
+            LocationCoordinate2D(latitude : -80.39657592773438, longitude : 27.980455528671527),
+            LocationCoordinate2D(latitude : -80.41305541992188, longitude : 27.982274659104082),
+            LocationCoordinate2D(latitude : -80.42953491210938, longitude : 27.990763528690582),
+            LocationCoordinate2D(latitude : -80.4144287109375, longitude : 28.00955793247135),
+            LocationCoordinate2D(latitude : -80.3594970703125, longitude : 27.972572275562527),
+            LocationCoordinate2D(latitude : -80.38215637207031, longitude : 27.913732900444284),
+            LocationCoordinate2D(latitude : -80.41786193847656, longitude : 27.881570017022806),
+            LocationCoordinate2D(latitude : -80.39382934570312, longitude : 27.85425440786446),
+            LocationCoordinate2D(latitude : -80.37803649902344, longitude : 27.86336037597851),
+            LocationCoordinate2D(latitude : -80.38215637207031, longitude : 27.880963078302393),
+            LocationCoordinate2D(latitude : -80.36842346191405, longitude : 27.888246118437756),
+            LocationCoordinate2D(latitude : -80.35743713378906, longitude : 27.882176952341734),
+            LocationCoordinate2D(latitude : -80.3594970703125, longitude : 27.8421119273228),
+            LocationCoordinate2D(latitude : -80.37940979003906, longitude : 27.83300417483936),
+            LocationCoordinate2D(latitude : -80.39932250976561, longitude : 27.82511017099003),
+            LocationCoordinate2D(latitude : -80.40069580078125, longitude : 27.79352841586229),
+            LocationCoordinate2D(latitude : -80.36155700683594, longitude : 27.786846483587688),
+            LocationCoordinate2D(latitude : -80.35537719726562, longitude : 27.794743268514615),
+            LocationCoordinate2D(latitude : -80.36705017089844, longitude : 27.800209937418252),
+            LocationCoordinate2D(latitude : -80.35932540893555, longitude : 27.806853088493792),
+            LocationCoordinate2D(latitude : -80.35499095916748, longitude : 27.796831264786892),
+            LocationCoordinate2D(latitude : -80.34404754638672, longitude : 27.802070060660014),
+            LocationCoordinate2D(latitude : -80.33499240875244, longitude : 27.810079615315917),
+            LocationCoordinate2D(latitude : -80.32872676849365, longitude : 27.80848534345178),
+        ]
         let original = LineString(coordinates)
         let simplified = original.simplify(tolerance: 0.01, highestQuality: false).coordinates
         XCTAssertEqual(simplified, simplifiedCoordinates)

--- a/Tests/TurfTests/MultiLineStringTests.swift
+++ b/Tests/TurfTests/MultiLineStringTests.swift
@@ -8,8 +8,8 @@ class MultiLineStringTests: XCTestCase {
     
     func testMultiLineStringFeature() {
         let data = try! Fixture.geojsonData(from: "multiline")!
-        let firstCoordinate = CLLocationCoordinate2D(latitude: 0, longitude: 0)
-        let lastCoordinate = CLLocationCoordinate2D(latitude: 6, longitude: 6)
+        let firstCoordinate = LocationCoordinate2D(latitude: 0, longitude: 0)
+        let lastCoordinate = LocationCoordinate2D(latitude: 6, longitude: 6)
         
         let geojson = try! GeoJSON.parse(Feature.self, from: data)
         

--- a/Tests/TurfTests/MultiPointTests.swift
+++ b/Tests/TurfTests/MultiPointTests.swift
@@ -8,8 +8,8 @@ class MultiPointTests: XCTestCase {
     
     func testMultiPointFeature() {
         let data = try! Fixture.geojsonData(from: "multipoint")!
-        let firstCoordinate = CLLocationCoordinate2D(latitude: 26.194876675795218, longitude: 14.765625)
-        let lastCoordinate = CLLocationCoordinate2D(latitude: 24.926294766395593, longitude: 17.75390625)
+        let firstCoordinate = LocationCoordinate2D(latitude: 26.194876675795218, longitude: 14.765625)
+        let lastCoordinate = LocationCoordinate2D(latitude: 24.926294766395593, longitude: 17.75390625)
         
         let geojson = try! GeoJSON.parse(Feature.self, from: data)
                 

--- a/Tests/TurfTests/MultiPolygonTests.swift
+++ b/Tests/TurfTests/MultiPolygonTests.swift
@@ -11,8 +11,8 @@ class MultiPolygonTests: XCTestCase {
     
     func testMultiPolygonFeature() {
         let data = try! Fixture.geojsonData(from: "multipolygon")!
-        let firstCoordinate = CLLocationCoordinate2D(latitude: 0, longitude: 0)
-        let lastCoordinate = CLLocationCoordinate2D(latitude: 11, longitude: 11)
+        let firstCoordinate = LocationCoordinate2D(latitude: 0, longitude: 0)
+        let lastCoordinate = LocationCoordinate2D(latitude: 11, longitude: 11)
         
         let geojson = try! GeoJSON.parse(Feature.self, from: data)
         
@@ -40,32 +40,34 @@ class MultiPolygonTests: XCTestCase {
         [
             [
                 [
-                    CLLocationCoordinate2D(latitude: 0, longitude: 0),
-                    CLLocationCoordinate2D(latitude: 0, longitude: 5),
-                    CLLocationCoordinate2D(latitude: 0, longitude: 5),
-                    CLLocationCoordinate2D(latitude: 0, longitude: 10),
-                    CLLocationCoordinate2D(latitude: 10, longitude: 10),
-                    CLLocationCoordinate2D(latitude: 10, longitude: 0),
-                    CLLocationCoordinate2D(latitude: 5, longitude: 0),
-                    CLLocationCoordinate2D(latitude: 0, longitude: 0),
-                ],[
-                    CLLocationCoordinate2D(latitude: 5, longitude: 1),
-                    CLLocationCoordinate2D(latitude: 7, longitude: 1),
-                    CLLocationCoordinate2D(latitude: 8.5, longitude: 1),
-                    CLLocationCoordinate2D(latitude: 8.5, longitude: 4.5),
-                    CLLocationCoordinate2D(latitude: 7, longitude: 4.5),
-                    CLLocationCoordinate2D(latitude: 5, longitude: 4.5),
-                    CLLocationCoordinate2D(latitude: 5, longitude: 1)
-                ]
-            ],[
+                    LocationCoordinate2D(latitude: 0, longitude: 0),
+                    LocationCoordinate2D(latitude: 0, longitude: 5),
+                    LocationCoordinate2D(latitude: 0, longitude: 5),
+                    LocationCoordinate2D(latitude: 0, longitude: 10),
+                    LocationCoordinate2D(latitude: 10, longitude: 10),
+                    LocationCoordinate2D(latitude: 10, longitude: 0),
+                    LocationCoordinate2D(latitude: 5, longitude: 0),
+                    LocationCoordinate2D(latitude: 0, longitude: 0),
+                ],
                 [
-                    CLLocationCoordinate2D(latitude: 11, longitude: 11),
-                    CLLocationCoordinate2D(latitude: 11.5, longitude: 11.5),
-                    CLLocationCoordinate2D(latitude: 12, longitude: 12),
-                    CLLocationCoordinate2D(latitude: 11, longitude: 12),
-                    CLLocationCoordinate2D(latitude: 11, longitude: 11.5),
-                    CLLocationCoordinate2D(latitude: 11, longitude: 11),
-                    CLLocationCoordinate2D(latitude: 11, longitude: 11)
+                    LocationCoordinate2D(latitude: 5, longitude: 1),
+                    LocationCoordinate2D(latitude: 7, longitude: 1),
+                    LocationCoordinate2D(latitude: 8.5, longitude: 1),
+                    LocationCoordinate2D(latitude: 8.5, longitude: 4.5),
+                    LocationCoordinate2D(latitude: 7, longitude: 4.5),
+                    LocationCoordinate2D(latitude: 5, longitude: 4.5),
+                    LocationCoordinate2D(latitude: 5, longitude: 1),
+                ]
+            ],
+            [
+                [
+                    LocationCoordinate2D(latitude: 11, longitude: 11),
+                    LocationCoordinate2D(latitude: 11.5, longitude: 11.5),
+                    LocationCoordinate2D(latitude: 12, longitude: 12),
+                    LocationCoordinate2D(latitude: 11, longitude: 12),
+                    LocationCoordinate2D(latitude: 11, longitude: 11.5),
+                    LocationCoordinate2D(latitude: 11, longitude: 11),
+                    LocationCoordinate2D(latitude: 11, longitude: 11),
                 ]
             ]
         ]
@@ -94,100 +96,96 @@ class MultiPolygonTests: XCTestCase {
     }
     
     func testMultiPolygonContains() {
-        let coordinate = CLLocationCoordinate2D(latitude: 44, longitude: -77)
-        let multiPolygon = MultiPolygon( [
+        let coordinate = LocationCoordinate2D(latitude: 44, longitude: -77)
+        let multiPolygon = MultiPolygon([
             Polygon([[
-                CLLocationCoordinate2D(latitude: 0, longitude: 0),
-                CLLocationCoordinate2D(latitude: 1, longitude: 0),
-                CLLocationCoordinate2D(latitude: 1, longitude: 1),
-                CLLocationCoordinate2D(latitude: 0, longitude: 1),
-                CLLocationCoordinate2D(latitude: 0, longitude: 0),
-                ]]),
+                LocationCoordinate2D(latitude: 0, longitude: 0),
+                LocationCoordinate2D(latitude: 1, longitude: 0),
+                LocationCoordinate2D(latitude: 1, longitude: 1),
+                LocationCoordinate2D(latitude: 0, longitude: 1),
+                LocationCoordinate2D(latitude: 0, longitude: 0),
+            ]]),
             Polygon([[
-                CLLocationCoordinate2D(latitude: 41, longitude: -81),
-                CLLocationCoordinate2D(latitude: 47, longitude: -81),
-                CLLocationCoordinate2D(latitude: 47, longitude: -72),
-                CLLocationCoordinate2D(latitude: 41, longitude: -72),
-                CLLocationCoordinate2D(latitude: 41, longitude: -81),
-                ]])
-            ]
-        )
+                LocationCoordinate2D(latitude: 41, longitude: -81),
+                LocationCoordinate2D(latitude: 47, longitude: -81),
+                LocationCoordinate2D(latitude: 47, longitude: -72),
+                LocationCoordinate2D(latitude: 41, longitude: -72),
+                LocationCoordinate2D(latitude: 41, longitude: -81),
+            ]])
+        ])
         XCTAssertTrue(multiPolygon.contains(coordinate))
     }
     
     func testMultiPolygonDoesNotContain() {
-        let coordinate = CLLocationCoordinate2D(latitude: 44, longitude: -87)
-        let multiPolygon = MultiPolygon( [
+        let coordinate = LocationCoordinate2D(latitude: 44, longitude: -87)
+        let multiPolygon = MultiPolygon([
             Polygon([[
-                CLLocationCoordinate2D(latitude: 0, longitude: 0),
-                CLLocationCoordinate2D(latitude: 1, longitude: 0),
-                CLLocationCoordinate2D(latitude: 1, longitude: 1),
-                CLLocationCoordinate2D(latitude: 0, longitude: 1),
-                CLLocationCoordinate2D(latitude: 0, longitude: 0),
-                ]]),
+                LocationCoordinate2D(latitude: 0, longitude: 0),
+                LocationCoordinate2D(latitude: 1, longitude: 0),
+                LocationCoordinate2D(latitude: 1, longitude: 1),
+                LocationCoordinate2D(latitude: 0, longitude: 1),
+                LocationCoordinate2D(latitude: 0, longitude: 0),
+            ]]),
             Polygon([[
-                CLLocationCoordinate2D(latitude: 41, longitude: -81),
-                CLLocationCoordinate2D(latitude: 47, longitude: -81),
-                CLLocationCoordinate2D(latitude: 47, longitude: -72),
-                CLLocationCoordinate2D(latitude: 41, longitude: -72),
-                CLLocationCoordinate2D(latitude: 41, longitude: -81),
-                ]])
-            ]
-        )
+                LocationCoordinate2D(latitude: 41, longitude: -81),
+                LocationCoordinate2D(latitude: 47, longitude: -81),
+                LocationCoordinate2D(latitude: 47, longitude: -72),
+                LocationCoordinate2D(latitude: 41, longitude: -72),
+                LocationCoordinate2D(latitude: 41, longitude: -81),
+            ]])
+        ])
         XCTAssertFalse(multiPolygon.contains(coordinate))
     }
     
     func testMultiPolygonDoesNotContainWithHole() {
-        let coordinate = CLLocationCoordinate2D(latitude: 44, longitude: -77)
+        let coordinate = LocationCoordinate2D(latitude: 44, longitude: -77)
         let polygon = Polygon([
             [
-                CLLocationCoordinate2D(latitude: 41, longitude: -81),
-                CLLocationCoordinate2D(latitude: 47, longitude: -81),
-                CLLocationCoordinate2D(latitude: 47, longitude: -72),
-                CLLocationCoordinate2D(latitude: 41, longitude: -72),
-                CLLocationCoordinate2D(latitude: 41, longitude: -81),
+                LocationCoordinate2D(latitude: 41, longitude: -81),
+                LocationCoordinate2D(latitude: 47, longitude: -81),
+                LocationCoordinate2D(latitude: 47, longitude: -72),
+                LocationCoordinate2D(latitude: 41, longitude: -72),
+                LocationCoordinate2D(latitude: 41, longitude: -81),
             ],
             [
-                CLLocationCoordinate2D(latitude: 43, longitude: -76),
-                CLLocationCoordinate2D(latitude: 43, longitude: -78),
-                CLLocationCoordinate2D(latitude: 45, longitude: -78),
-                CLLocationCoordinate2D(latitude: 45, longitude: -76),
-                CLLocationCoordinate2D(latitude: 43, longitude: -76),
+                LocationCoordinate2D(latitude: 43, longitude: -76),
+                LocationCoordinate2D(latitude: 43, longitude: -78),
+                LocationCoordinate2D(latitude: 45, longitude: -78),
+                LocationCoordinate2D(latitude: 45, longitude: -76),
+                LocationCoordinate2D(latitude: 43, longitude: -76),
             ],
         ])
-        let multiPolygon = MultiPolygon( [
+        let multiPolygon = MultiPolygon([
             polygon,
             Polygon([[
-                CLLocationCoordinate2D(latitude: 0, longitude: 0),
-                CLLocationCoordinate2D(latitude: 1, longitude: 0),
-                CLLocationCoordinate2D(latitude: 1, longitude: 1),
-                CLLocationCoordinate2D(latitude: 0, longitude: 1),
-                CLLocationCoordinate2D(latitude: 0, longitude: 0),
-                ]])
-            ]
-        )
+                LocationCoordinate2D(latitude: 0, longitude: 0),
+                LocationCoordinate2D(latitude: 1, longitude: 0),
+                LocationCoordinate2D(latitude: 1, longitude: 1),
+                LocationCoordinate2D(latitude: 0, longitude: 1),
+                LocationCoordinate2D(latitude: 0, longitude: 0),
+            ]])
+        ])
         XCTAssertFalse(multiPolygon.contains(coordinate))
     }
 
     func testMultiPolygonContainsAtBoundary() {
-        let coordinate = CLLocationCoordinate2D(latitude: 1, longitude: 1)
-        let multiPolygon = MultiPolygon( [
+        let coordinate = LocationCoordinate2D(latitude: 1, longitude: 1)
+        let multiPolygon = MultiPolygon([
             [[
-                CLLocationCoordinate2D(latitude: 0, longitude: 0),
-                CLLocationCoordinate2D(latitude: 1, longitude: 0),
-                CLLocationCoordinate2D(latitude: 1, longitude: 1),
-                CLLocationCoordinate2D(latitude: 0, longitude: 1),
-                CLLocationCoordinate2D(latitude: 0, longitude: 0),
-                ]],
+                LocationCoordinate2D(latitude: 0, longitude: 0),
+                LocationCoordinate2D(latitude: 1, longitude: 0),
+                LocationCoordinate2D(latitude: 1, longitude: 1),
+                LocationCoordinate2D(latitude: 0, longitude: 1),
+                LocationCoordinate2D(latitude: 0, longitude: 0),
+            ]],
             [[
-                CLLocationCoordinate2D(latitude: 41, longitude: -81),
-                CLLocationCoordinate2D(latitude: 47, longitude: -81),
-                CLLocationCoordinate2D(latitude: 47, longitude: -72),
-                CLLocationCoordinate2D(latitude: 41, longitude: -72),
-                CLLocationCoordinate2D(latitude: 41, longitude: -81),
-                ]]
-            ]
-        )
+                LocationCoordinate2D(latitude: 41, longitude: -81),
+                LocationCoordinate2D(latitude: 47, longitude: -81),
+                LocationCoordinate2D(latitude: 47, longitude: -72),
+                LocationCoordinate2D(latitude: 41, longitude: -72),
+                LocationCoordinate2D(latitude: 41, longitude: -81),
+            ]]
+        ])
 
         XCTAssertFalse(multiPolygon.contains(coordinate, ignoreBoundary: true))
         XCTAssertTrue(multiPolygon.contains(coordinate, ignoreBoundary: false))
@@ -195,33 +193,32 @@ class MultiPolygonTests: XCTestCase {
     }
 
     func testMultiPolygonWithHoleContainsAtBoundary() {
-        let coordinate = CLLocationCoordinate2D(latitude: 43, longitude: -78)
+        let coordinate = LocationCoordinate2D(latitude: 43, longitude: -78)
         let multiPolygon = MultiPolygon( [
             [
                 [
-                    CLLocationCoordinate2D(latitude: 41, longitude: -81),
-                    CLLocationCoordinate2D(latitude: 47, longitude: -81),
-                    CLLocationCoordinate2D(latitude: 47, longitude: -72),
-                    CLLocationCoordinate2D(latitude: 41, longitude: -72),
-                    CLLocationCoordinate2D(latitude: 41, longitude: -81),
+                    LocationCoordinate2D(latitude: 41, longitude: -81),
+                    LocationCoordinate2D(latitude: 47, longitude: -81),
+                    LocationCoordinate2D(latitude: 47, longitude: -72),
+                    LocationCoordinate2D(latitude: 41, longitude: -72),
+                    LocationCoordinate2D(latitude: 41, longitude: -81),
                 ],
                 [
-                    CLLocationCoordinate2D(latitude: 43, longitude: -76),
-                    CLLocationCoordinate2D(latitude: 43, longitude: -78),
-                    CLLocationCoordinate2D(latitude: 45, longitude: -78),
-                    CLLocationCoordinate2D(latitude: 45, longitude: -76),
-                    CLLocationCoordinate2D(latitude: 43, longitude: -76),
+                    LocationCoordinate2D(latitude: 43, longitude: -76),
+                    LocationCoordinate2D(latitude: 43, longitude: -78),
+                    LocationCoordinate2D(latitude: 45, longitude: -78),
+                    LocationCoordinate2D(latitude: 45, longitude: -76),
+                    LocationCoordinate2D(latitude: 43, longitude: -76),
                 ]
             ],
             [[
-                CLLocationCoordinate2D(latitude: 0, longitude: 0),
-                CLLocationCoordinate2D(latitude: 1, longitude: 0),
-                CLLocationCoordinate2D(latitude: 1, longitude: 1),
-                CLLocationCoordinate2D(latitude: 0, longitude: 1),
-                CLLocationCoordinate2D(latitude: 0, longitude: 0),
-                ]]
-            ]
-        )
+                LocationCoordinate2D(latitude: 0, longitude: 0),
+                LocationCoordinate2D(latitude: 1, longitude: 0),
+                LocationCoordinate2D(latitude: 1, longitude: 1),
+                LocationCoordinate2D(latitude: 0, longitude: 1),
+                LocationCoordinate2D(latitude: 0, longitude: 0),
+            ]]
+        ])
 
         XCTAssertFalse(multiPolygon.contains(coordinate, ignoreBoundary: true))
         XCTAssertTrue(multiPolygon.contains(coordinate, ignoreBoundary: false))

--- a/Tests/TurfTests/PointTests.swift
+++ b/Tests/TurfTests/PointTests.swift
@@ -9,7 +9,7 @@ class PointTests: XCTestCase {
     func testPointFeature() {
         let data = try! Fixture.geojsonData(from: "point")!
         let geojson = try! GeoJSON.parse(Feature.self, from: data)
-        let coordinate = CLLocationCoordinate2D(latitude: 26.194876675795218, longitude: 14.765625)
+        let coordinate = LocationCoordinate2D(latitude: 26.194876675795218, longitude: 14.765625)
 
         guard case let .point(point) = geojson.geometry else {
             XCTFail()

--- a/Tests/TurfTests/PolygonTests.swift
+++ b/Tests/TurfTests/PolygonTests.swift
@@ -10,8 +10,8 @@ class PolygonTests: XCTestCase {
         let data = try! Fixture.geojsonData(from: "polygon")!
         let geojson = try! GeoJSON.parse(Feature.self, from: data)
         
-        let firstCoordinate = CLLocationCoordinate2D(latitude: 37.00255267215955, longitude: -109.05029296875)
-        let lastCoordinate = CLLocationCoordinate2D(latitude: 40.6306300839918, longitude: -108.56689453125)
+        let firstCoordinate = LocationCoordinate2D(latitude: 37.00255267215955, longitude: -109.05029296875)
+        let lastCoordinate = LocationCoordinate2D(latitude: 40.6306300839918, longitude: -108.56689453125)
         
         XCTAssert((geojson.identifier!.value as! Number).value! as! Double == 1.01)
         
@@ -40,59 +40,59 @@ class PolygonTests: XCTestCase {
     }
     
     func testPolygonContains() {
-        let coordinate = CLLocationCoordinate2D(latitude: 44, longitude: -77)
+        let coordinate = LocationCoordinate2D(latitude: 44, longitude: -77)
         let polygon = Polygon([[
-            CLLocationCoordinate2D(latitude: 41, longitude: -81),
-            CLLocationCoordinate2D(latitude: 47, longitude: -81),
-            CLLocationCoordinate2D(latitude: 47, longitude: -72),
-            CLLocationCoordinate2D(latitude: 41, longitude: -72),
-            CLLocationCoordinate2D(latitude: 41, longitude: -81),
-            ]])
+            LocationCoordinate2D(latitude: 41, longitude: -81),
+            LocationCoordinate2D(latitude: 47, longitude: -81),
+            LocationCoordinate2D(latitude: 47, longitude: -72),
+            LocationCoordinate2D(latitude: 41, longitude: -72),
+            LocationCoordinate2D(latitude: 41, longitude: -81),
+        ]])
         XCTAssertTrue(polygon.contains(coordinate))
     }
     
     func testPolygonDoesNotContain() {
-        let coordinate = CLLocationCoordinate2D(latitude: 44, longitude: -77)
+        let coordinate = LocationCoordinate2D(latitude: 44, longitude: -77)
         let polygon = Polygon([[
-            CLLocationCoordinate2D(latitude: 41, longitude: -51),
-            CLLocationCoordinate2D(latitude: 47, longitude: -51),
-            CLLocationCoordinate2D(latitude: 47, longitude: -42),
-            CLLocationCoordinate2D(latitude: 41, longitude: -42),
-            CLLocationCoordinate2D(latitude: 41, longitude: -51),
-            ]])
+            LocationCoordinate2D(latitude: 41, longitude: -51),
+            LocationCoordinate2D(latitude: 47, longitude: -51),
+            LocationCoordinate2D(latitude: 47, longitude: -42),
+            LocationCoordinate2D(latitude: 41, longitude: -42),
+            LocationCoordinate2D(latitude: 41, longitude: -51),
+        ]])
         XCTAssertFalse(polygon.contains(coordinate))
     }
     
     func testPolygonDoesNotContainWithHole() {
-        let coordinate = CLLocationCoordinate2D(latitude: 44, longitude: -77)
+        let coordinate = LocationCoordinate2D(latitude: 44, longitude: -77)
         let polygon = Polygon([
             [
-                CLLocationCoordinate2D(latitude: 41, longitude: -81),
-                CLLocationCoordinate2D(latitude: 47, longitude: -81),
-                CLLocationCoordinate2D(latitude: 47, longitude: -72),
-                CLLocationCoordinate2D(latitude: 41, longitude: -72),
-                CLLocationCoordinate2D(latitude: 41, longitude: -81),
+                LocationCoordinate2D(latitude: 41, longitude: -81),
+                LocationCoordinate2D(latitude: 47, longitude: -81),
+                LocationCoordinate2D(latitude: 47, longitude: -72),
+                LocationCoordinate2D(latitude: 41, longitude: -72),
+                LocationCoordinate2D(latitude: 41, longitude: -81),
             ],
             [
-                CLLocationCoordinate2D(latitude: 43, longitude: -76),
-                CLLocationCoordinate2D(latitude: 43, longitude: -78),
-                CLLocationCoordinate2D(latitude: 45, longitude: -78),
-                CLLocationCoordinate2D(latitude: 45, longitude: -76),
-                CLLocationCoordinate2D(latitude: 43, longitude: -76),
+                LocationCoordinate2D(latitude: 43, longitude: -76),
+                LocationCoordinate2D(latitude: 43, longitude: -78),
+                LocationCoordinate2D(latitude: 45, longitude: -78),
+                LocationCoordinate2D(latitude: 45, longitude: -76),
+                LocationCoordinate2D(latitude: 43, longitude: -76),
             ],
         ])
         XCTAssertFalse(polygon.contains(coordinate))
     }
 
     func testPolygonContainsAtBoundary() {
-        let coordinate = CLLocationCoordinate2D(latitude: 1, longitude: 1)
+        let coordinate = LocationCoordinate2D(latitude: 1, longitude: 1)
         let polygon = Polygon([[
-            CLLocationCoordinate2D(latitude: 0, longitude: 0),
-            CLLocationCoordinate2D(latitude: 1, longitude: 0),
-            CLLocationCoordinate2D(latitude: 1, longitude: 1),
-            CLLocationCoordinate2D(latitude: 0, longitude: 1),
-            CLLocationCoordinate2D(latitude: 0, longitude: 0),
-            ]])
+            LocationCoordinate2D(latitude: 0, longitude: 0),
+            LocationCoordinate2D(latitude: 1, longitude: 0),
+            LocationCoordinate2D(latitude: 1, longitude: 1),
+            LocationCoordinate2D(latitude: 0, longitude: 1),
+            LocationCoordinate2D(latitude: 0, longitude: 0),
+        ]])
 
         XCTAssertFalse(polygon.contains(coordinate, ignoreBoundary: true))
         XCTAssertTrue(polygon.contains(coordinate, ignoreBoundary: false))
@@ -100,21 +100,21 @@ class PolygonTests: XCTestCase {
     }
 
     func testPolygonWithHoleContainsAtBoundary() {
-        let coordinate = CLLocationCoordinate2D(latitude: 43, longitude: -78)
+        let coordinate = LocationCoordinate2D(latitude: 43, longitude: -78)
         let polygon = Polygon([
             [
-                CLLocationCoordinate2D(latitude: 41, longitude: -81),
-                CLLocationCoordinate2D(latitude: 47, longitude: -81),
-                CLLocationCoordinate2D(latitude: 47, longitude: -72),
-                CLLocationCoordinate2D(latitude: 41, longitude: -72),
-                CLLocationCoordinate2D(latitude: 41, longitude: -81),
+                LocationCoordinate2D(latitude: 41, longitude: -81),
+                LocationCoordinate2D(latitude: 47, longitude: -81),
+                LocationCoordinate2D(latitude: 47, longitude: -72),
+                LocationCoordinate2D(latitude: 41, longitude: -72),
+                LocationCoordinate2D(latitude: 41, longitude: -81),
             ],
             [
-                CLLocationCoordinate2D(latitude: 43, longitude: -76),
-                CLLocationCoordinate2D(latitude: 43, longitude: -78),
-                CLLocationCoordinate2D(latitude: 45, longitude: -78),
-                CLLocationCoordinate2D(latitude: 45, longitude: -76),
-                CLLocationCoordinate2D(latitude: 43, longitude: -76),
+                LocationCoordinate2D(latitude: 43, longitude: -76),
+                LocationCoordinate2D(latitude: 43, longitude: -78),
+                LocationCoordinate2D(latitude: 45, longitude: -78),
+                LocationCoordinate2D(latitude: 45, longitude: -76),
+                LocationCoordinate2D(latitude: 43, longitude: -76),
             ],
         ])
 
@@ -125,9 +125,9 @@ class PolygonTests: XCTestCase {
 
     func testCirclePolygon()
     {
-        let coord = CLLocationCoordinate2D(latitude: 10.0, longitude: 5.0)
+        let coord = LocationCoordinate2D(latitude: 10.0, longitude: 5.0)
         let radius = 500
-        let circleShape = Polygon(center: coord, radius: CLLocationDistance(radius), vertices: 64)
+        let circleShape = Polygon(center: coord, radius: LocationDistance(radius), vertices: 64)
 
         // Test number of vertices is 64.
         let expctedNumberOfSteps = circleShape.coordinates[0].count - 1
@@ -137,7 +137,7 @@ class PolygonTests: XCTestCase {
         let startingCoord = circleShape.coordinates[0][0]
         let oppositeCoord = circleShape.coordinates[0][circleShape.coordinates[0].count / 2]
 
-        let expectedDiameter = CLLocationDistance(radius * 2)
+        let expectedDiameter = LocationDistance(radius * 2)
         let diameter = startingCoord.distance(to: oppositeCoord)
 
         XCTAssertEqual(expectedDiameter, diameter, accuracy: 0.25)

--- a/Tests/TurfTests/TurfTests.swift
+++ b/Tests/TurfTests/TurfTests.swift
@@ -4,7 +4,7 @@ import CoreLocation
 #endif
 @testable import Turf
 
-let metersPerMile: CLLocationDistance = 1_609.344
+let metersPerMile: LocationDistance = 1_609.344
 
 #if swift(>=3.2)
 #else
@@ -16,16 +16,16 @@ func XCTAssertEqual<T: FloatingPoint>(_ lhs: @autoclosure () throws -> T, _ rhs:
 class TurfTests: XCTestCase {
     
     func testWrap() {
-        let a = (380 as CLLocationDirection).wrap(min: 0, max: 360)
+        let a = (380 as LocationDirection).wrap(min: 0, max: 360)
         XCTAssertEqual(a, 20)
         
-        let b = (-30 as CLLocationDirection).wrap(min: 0, max: 360)
+        let b = (-30 as LocationDirection).wrap(min: 0, max: 360)
         XCTAssertEqual(b, 330)
     }
     
     func testCLLocationCoordinate2() {
-        let coord1 = CLLocationCoordinate2D(latitude: 35, longitude: 35)
-        let coord2 = CLLocationCoordinate2D(latitude: -10, longitude: -10)
+        let coord1 = LocationCoordinate2D(latitude: 35, longitude: 35)
+        let coord2 = LocationCoordinate2D(latitude: -10, longitude: -10)
         let a = coord1.direction(to: coord2)
         XCTAssertEqual(a, -128, accuracy: 1)
         
@@ -35,8 +35,8 @@ class TurfTests: XCTestCase {
     }
     
     func testIntersection() {
-        let coord1 = CLLocationCoordinate2D(latitude: 30, longitude: 30)
-        let a = intersection((CLLocationCoordinate2D(latitude: 20, longitude: 20), CLLocationCoordinate2D(latitude: 40, longitude: 40)), (CLLocationCoordinate2D(latitude: 20, longitude: 40), CLLocationCoordinate2D(latitude: 40, longitude: 20)))
+        let coord1 = LocationCoordinate2D(latitude: 30, longitude: 30)
+        let a = intersection((LocationCoordinate2D(latitude: 20, longitude: 20), LocationCoordinate2D(latitude: 40, longitude: 40)), (LocationCoordinate2D(latitude: 20, longitude: 40), LocationCoordinate2D(latitude: 40, longitude: 20)))
         XCTAssertEqual(a, coord1)
     }
     
@@ -55,7 +55,7 @@ class TurfTests: XCTestCase {
         let geometry = json["geometry"] as! [String: Any]
         let geoJSONCoordinates = geometry["coordinates"] as! [[[Double]]]
         let coordinates = geoJSONCoordinates.map {
-           $0.map { CLLocationCoordinate2D(latitude: $0[1], longitude: $0[0]) }
+           $0.map { LocationCoordinate2D(latitude: $0[1], longitude: $0[0]) }
         }
         
         let polygon = Polygon(coordinates)
@@ -64,8 +64,8 @@ class TurfTests: XCTestCase {
     }
     
     func testBezierSplineTwoPoints() {
-        let point1 = CLLocationCoordinate2D(latitude: 37.7749, longitude: 237.581)
-        let point2 = CLLocationCoordinate2D(latitude: 35.6669502038, longitude: 139.7731286197)
+        let point1 = LocationCoordinate2D(latitude: 37.7749, longitude: 237.581)
+        let point2 = LocationCoordinate2D(latitude: 35.6669502038, longitude: 139.7731286197)
         let line = [point1, point2]
         let lineString = LineString(line)
         guard let bezierLineString = lineString.bezier() else {
@@ -84,10 +84,10 @@ class TurfTests: XCTestCase {
     }
     
     func testBezierSplineSimple() {
-        let point1 = CLLocationCoordinate2D(latitude: -22.91792293614603, longitude: 121.025390625)
-        let point2 = CLLocationCoordinate2D(latitude: -19.394067895396613, longitude: 130.6494140625)
-        let point3 = CLLocationCoordinate2D(latitude: -25.681137335685307, longitude: 138.33984375)
-        let point4 = CLLocationCoordinate2D(latitude: -32.026706293336126, longitude: 138.3837890625)
+        let point1 = LocationCoordinate2D(latitude: -22.91792293614603, longitude: 121.025390625)
+        let point2 = LocationCoordinate2D(latitude: -19.394067895396613, longitude: 130.6494140625)
+        let point3 = LocationCoordinate2D(latitude: -25.681137335685307, longitude: 138.33984375)
+        let point4 = LocationCoordinate2D(latitude: -32.026706293336126, longitude: 138.3837890625)
         let line = [point1, point2, point3, point4]
         let lineString = LineString(line)
         guard let bezierLineString = lineString.bezier() else {
@@ -107,8 +107,8 @@ class TurfTests: XCTestCase {
     
     func testMidHorizEquator()
     {
-        let coord1 = CLLocationCoordinate2D(latitude: 0.0, longitude: 0.0)
-        let coord2 = CLLocationCoordinate2D(latitude: 0.0, longitude: 10.0)
+        let coord1 = LocationCoordinate2D(latitude: 0.0, longitude: 0.0)
+        let coord2 = LocationCoordinate2D(latitude: 0.0, longitude: 10.0)
         
         let midCoord = mid(coord1, coord2)
         XCTAssertEqual(coord1.distance(to: midCoord), coord2.distance(to: midCoord), accuracy: 1)
@@ -116,8 +116,8 @@ class TurfTests: XCTestCase {
     
     func testMidVertFromEquator()
     {
-        let coord1 = CLLocationCoordinate2D(latitude: 0.0, longitude: 0.0)
-        let coord2 = CLLocationCoordinate2D(latitude: 10.0, longitude: 0.0)
+        let coord1 = LocationCoordinate2D(latitude: 0.0, longitude: 0.0)
+        let coord2 = LocationCoordinate2D(latitude: 10.0, longitude: 0.0)
         
         let midCoord = mid(coord1, coord2)
         XCTAssertEqual(coord1.distance(to: midCoord), coord2.distance(to: midCoord), accuracy: 1)
@@ -125,8 +125,8 @@ class TurfTests: XCTestCase {
     
     func testMidVertToEquator()
     {
-        let coord1 = CLLocationCoordinate2D(latitude: 10.0, longitude: 0.0)
-        let coord2 = CLLocationCoordinate2D(latitude: 0.0, longitude: 0.0)
+        let coord1 = LocationCoordinate2D(latitude: 10.0, longitude: 0.0)
+        let coord2 = LocationCoordinate2D(latitude: 0.0, longitude: 0.0)
         
         let midCoord = mid(coord1, coord2)
         XCTAssertEqual(coord1.distance(to: midCoord), coord2.distance(to: midCoord), accuracy: 1)
@@ -134,8 +134,8 @@ class TurfTests: XCTestCase {
     
     func testMidDiagonalBackOverEquator()
     {
-        let coord1 = CLLocationCoordinate2D(latitude: 10.0, longitude: -1.0)
-        let coord2 = CLLocationCoordinate2D(latitude: -1.0, longitude: 1.0)
+        let coord1 = LocationCoordinate2D(latitude: 10.0, longitude: -1.0)
+        let coord2 = LocationCoordinate2D(latitude: -1.0, longitude: 1.0)
         
         let midCoord = mid(coord1, coord2)
         XCTAssertEqual(coord1.distance(to: midCoord), coord2.distance(to: midCoord), accuracy: 1)
@@ -143,8 +143,8 @@ class TurfTests: XCTestCase {
     
     func testMidDiagonalForwardOverEquator()
     {
-        let coord1 = CLLocationCoordinate2D(latitude: -1.0, longitude: -5.0)
-        let coord2 = CLLocationCoordinate2D(latitude: 10.0, longitude: 5.0)
+        let coord1 = LocationCoordinate2D(latitude: -1.0, longitude: -5.0)
+        let coord2 = LocationCoordinate2D(latitude: 10.0, longitude: 5.0)
         
         let midCoord = mid(coord1, coord2)
         XCTAssertEqual(coord1.distance(to: midCoord), coord2.distance(to: midCoord), accuracy: 1)
@@ -152,8 +152,8 @@ class TurfTests: XCTestCase {
     
     func testMidLongDistance()
     {
-        let coord1 = CLLocationCoordinate2D(latitude: 21.94304553343818, longitude: 22.5)
-        let coord2 = CLLocationCoordinate2D(latitude: 46.800059446787316, longitude: 92.10937499999999)
+        let coord1 = LocationCoordinate2D(latitude: 21.94304553343818, longitude: 22.5)
+        let coord2 = LocationCoordinate2D(latitude: 46.800059446787316, longitude: 92.10937499999999)
         
         let midCoord = mid(coord1, coord2)
         XCTAssertEqual(coord1.distance(to: midCoord), coord2.distance(to: midCoord), accuracy: 1)


### PR DESCRIPTION
Rewrote the Core Location compatibility shim for Linux to define non-CL-prefixed types regardless of platform. For example, cross-platform code uses `LocationCoordinate2D` instead of `CLLocationCoordinate2D`, but Apple-platform code can continue to use `CLLocationCoordinate2D`.

Along the way, this PR also renames `BoundingBox(_:_:)` to `BoundingBox(southWest:northEast:)` to avoid mistakes similar to #102 in client code.

Fixes #119.

/cc @mapbox/navigation-ios @macdrevx