### PR TITLE
Use Measurement API instead of RadianDirection typealias

### DIFF
--- a/Sources/Turf/CoreLocation.swift
+++ b/Sources/Turf/CoreLocation.swift
@@ -188,12 +188,13 @@ extension LocationCoordinate2D: Equatable {
     
     /// Returns the direction from the receiver to the given coordinate.
     public func direction(to coordinate: LocationCoordinate2D) -> LocationDirection {
-        return RadianCoordinate2D(self).direction(to: RadianCoordinate2D(coordinate)).toDegrees()
+        return RadianCoordinate2D(self).direction(to: RadianCoordinate2D(coordinate)).converted(to: .degrees).value
     }
     
     /// Returns a coordinate a certain Haversine distance away in the given direction.
     public func coordinate(at distance: LocationDistance, facing direction: LocationDirection) -> LocationCoordinate2D {
-        let radianCoordinate = RadianCoordinate2D(self).coordinate(at: distance / metersPerRadian, facing: direction.toRadians())
+        let radiansDirection = Measurement(value: direction, unit: UnitAngle.degrees)
+        let radianCoordinate = RadianCoordinate2D(self).coordinate(at: distance / metersPerRadian, facing: radiansDirection)
         return LocationCoordinate2D(radianCoordinate)
     }
     

--- a/Sources/Turf/CoreLocation.swift
+++ b/Sources/Turf/CoreLocation.swift
@@ -193,8 +193,13 @@ extension LocationCoordinate2D: Equatable {
     
     /// Returns a coordinate a certain Haversine distance away in the given direction.
     public func coordinate(at distance: LocationDistance, facing direction: LocationDirection) -> LocationCoordinate2D {
-        let radiansDirection = Measurement(value: direction, unit: UnitAngle.degrees)
-        let radianCoordinate = RadianCoordinate2D(self).coordinate(at: distance / metersPerRadian, facing: radiansDirection)
+        let angle = Measurement(value: direction, unit: UnitAngle.degrees)
+        return coordinate(at: distance, facing: angle)
+    }
+
+    /// Returns a coordinate a certain Haversine distance away in the given direction.
+    public func coordinate(at distance: LocationDistance, facing direction: Measurement<UnitAngle>) -> LocationCoordinate2D {
+        let radianCoordinate = RadianCoordinate2D(self).coordinate(at: distance / metersPerRadian, facing: direction)
         return LocationCoordinate2D(radianCoordinate)
     }
     

--- a/Sources/Turf/RadianCoordinate2D.swift
+++ b/Sources/Turf/RadianCoordinate2D.swift
@@ -5,7 +5,6 @@ import CoreLocation
 
 public typealias LocationRadians = Double
 public typealias RadianDistance = Double
-public typealias RadianDirection = Double
 
 /**
  A `RadianCoordinate2D` is a coordinate represented in radians as opposed to
@@ -28,21 +27,22 @@ public struct RadianCoordinate2D {
     /**
      Returns direction given two coordinates.
      */
-    public func direction(to coordinate: RadianCoordinate2D) -> RadianDirection {
+    public func direction(to coordinate: RadianCoordinate2D) -> Measurement<UnitAngle> {
         let a = sin(coordinate.longitude - longitude) * cos(coordinate.latitude)
         let b = cos(latitude) * sin(coordinate.latitude)
             - sin(latitude) * cos(coordinate.latitude) * cos(coordinate.longitude - longitude)
-        return atan2(a, b)
+        return Measurement(value: atan2(a, b), unit: UnitAngle.radians)
     }
     
     /**
      Returns coordinate at a given distance and direction away from coordinate.
      */
-    public func coordinate(at distance: RadianDistance, facing direction: RadianDirection) -> RadianCoordinate2D {
+    public func coordinate(at distance: RadianDistance, facing direction: Measurement<UnitAngle>) -> RadianCoordinate2D {
         let distance = distance, direction = direction
+        let radiansDirection = direction.converted(to: .radians).value
         let otherLatitude = asin(sin(latitude) * cos(distance)
-            + cos(latitude) * sin(distance) * cos(direction))
-        let otherLongitude = longitude + atan2(sin(direction) * sin(distance) * cos(latitude),
+            + cos(latitude) * sin(distance) * cos(radiansDirection))
+        let otherLongitude = longitude + atan2(sin(radiansDirection) * sin(distance) * cos(latitude),
                                                cos(distance) - sin(latitude) * sin(otherLatitude))
         return RadianCoordinate2D(latitude: otherLatitude, longitude: otherLongitude)
     }

--- a/Tests/TurfTests/LocationCoordinate2DTests.swift
+++ b/Tests/TurfTests/LocationCoordinate2DTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+#if !os(Linux)
+import CoreLocation
+#endif
+@testable import Turf
+
+class LocationCoordinate2DTests: XCTestCase {
+
+    func testCalculatesDirection() {
+        let startCoordinate = LocationCoordinate2D(latitude: 35, longitude: 35)
+        let endCoordianate = LocationCoordinate2D(latitude: -10, longitude: -10)
+        let angle = startCoordinate.direction(to: endCoordianate)
+        XCTAssertEqual(angle, -128, accuracy: 1)
+    }
+
+    func testCalculatesCoordinateFacingDirectionInDegrees() {
+        let startCoordianate = LocationCoordinate2D(latitude: 35, longitude: 35)
+        let angleInDegrees = Measurement<UnitAngle>(value: 45, unit: .degrees)
+        let endCoordinate = startCoordianate.coordinate(at: 20 * metersPerRadian, facing: angleInDegrees)
+        XCTAssertEqual(endCoordinate.latitude, 49.7, accuracy: 0.1)
+        XCTAssertEqual(endCoordinate.longitude, 128.2, accuracy: 0.1)
+    }
+
+    func testCalculatesCoordinateFacingDirectionInRadians() {
+        let startCoordianate = LocationCoordinate2D(latitude: 35, longitude: 35)
+        let angleInRadians = Measurement<UnitAngle>(value: 0.35, unit: .radians)
+        let endCoordinate = startCoordianate.coordinate(at: 20 * metersPerRadian, facing: angleInRadians)
+        XCTAssertEqual(endCoordinate.latitude, 69.5, accuracy: 0.1)
+        XCTAssertEqual(endCoordinate.longitude, 151.7, accuracy: 0.1)
+    }
+
+    func testDeprecatedCalculationOfCoordinateFacingDirectionInDegrees() {
+        let startCoordianate = LocationCoordinate2D(latitude: 35, longitude: 35)
+        let endCoordinate = startCoordianate.coordinate(at: 20 * metersPerRadian, facing: 0)
+        XCTAssertEqual(endCoordinate.latitude, 79, accuracy: 0.1)
+        XCTAssertEqual(endCoordinate.longitude, 215, accuracy: 0.1)
+    }
+}

--- a/Tests/TurfTests/RadianCoordinate2DTests.swift
+++ b/Tests/TurfTests/RadianCoordinate2DTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+#if !os(Linux)
+import CoreLocation
+#endif
+@testable import Turf
+
+class RadianCoordinate2DTests: XCTestCase {
+
+    func testCalculatesDirection() {
+        let startCoordinate = RadianCoordinate2D(latitude: 35, longitude: 35)
+        let endCoordianate = RadianCoordinate2D(latitude: -10, longitude: -10)
+        let angle = startCoordinate.direction(to: endCoordianate)
+        XCTAssertEqual(angle.value, 2.3, accuracy: 0.1)
+        XCTAssertEqual(angle.unit, .radians)
+    }
+
+    func testCalculatesCoordinateFacingDirectionInDegrees() {
+        let startCoordianate = RadianCoordinate2D(latitude: 35, longitude: 35)
+        let angleInDegrees = Measurement<UnitAngle>(value: 45, unit: .degrees)
+        let endCoordinate = startCoordianate.coordinate(at: 20, facing: angleInDegrees)
+        XCTAssertEqual(endCoordinate.latitude, -0.8, accuracy: 0.1)
+        XCTAssertEqual(endCoordinate.longitude, 33.6, accuracy: 0.1)
+    }
+
+    func testCalculatesCoordinateFacingDirectionInRadians() {
+        let startCoordianate = RadianCoordinate2D(latitude: 35, longitude: 35)
+        let angleInRadians = Measurement<UnitAngle>(value: 0.35, unit: .radians)
+        let endCoordinate = startCoordianate.coordinate(at: 20, facing: angleInRadians)
+        XCTAssertEqual(endCoordinate.latitude, -1.25, accuracy: 0.1)
+        XCTAssertEqual(endCoordinate.longitude, 33.4, accuracy: 0.1)
+    }
+
+    func testCalculatesDistanceBetweenCoordinates() {
+        let startCoordianate = RadianCoordinate2D(latitude: 35, longitude: 35)
+        let endCoordianate = RadianCoordinate2D(latitude: -10, longitude: -10)
+        let distance = startCoordianate.distance(to: endCoordianate)
+        XCTAssertEqual(distance, 1.4, accuracy: 0.1)
+    }
+}

--- a/Turf.xcodeproj/project.pbxproj
+++ b/Turf.xcodeproj/project.pbxproj
@@ -7,6 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		11E726FA26247D3900C1890B /* LocationCoordinate2DTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E726F926247D3900C1890B /* LocationCoordinate2DTests.swift */; };
+		11E726FB26247D3900C1890B /* LocationCoordinate2DTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E726F926247D3900C1890B /* LocationCoordinate2DTests.swift */; };
+		11E7270326247D4000C1890B /* LocationCoordinate2DTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E726F926247D3900C1890B /* LocationCoordinate2DTests.swift */; };
+		11E7270C2624840900C1890B /* RadianCoordinate2DTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E7270B2624840900C1890B /* RadianCoordinate2DTests.swift */; };
+		11E7270D2624840900C1890B /* RadianCoordinate2DTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E7270B2624840900C1890B /* RadianCoordinate2DTests.swift */; };
+		11E7270E2624840900C1890B /* RadianCoordinate2DTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E7270B2624840900C1890B /* RadianCoordinate2DTests.swift */; };
 		2B5FABFD24066EB7008A285F /* geometry-collection.geojson in Resources */ = {isa = PBXBuildFile; fileRef = 2B5FABFB24066EA5008A285F /* geometry-collection.geojson */; };
 		2B5FABFE24066EB8008A285F /* geometry-collection.geojson in Resources */ = {isa = PBXBuildFile; fileRef = 2B5FABFB24066EA5008A285F /* geometry-collection.geojson */; };
 		2B5FABFF24066EB9008A285F /* geometry-collection.geojson in Resources */ = {isa = PBXBuildFile; fileRef = 2B5FABFB24066EA5008A285F /* geometry-collection.geojson */; };
@@ -183,6 +189,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		11E726F926247D3900C1890B /* LocationCoordinate2DTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationCoordinate2DTests.swift; sourceTree = "<group>"; };
+		11E7270B2624840900C1890B /* RadianCoordinate2DTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadianCoordinate2DTests.swift; sourceTree = "<group>"; };
 		2B5FABFB24066EA5008A285F /* geometry-collection.geojson */ = {isa = PBXFileReference; lastKnownFileType = text; path = "geometry-collection.geojson"; sourceTree = "<group>"; };
 		2B5FAC0024067051008A285F /* GeometryCollectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeometryCollectionTests.swift; sourceTree = "<group>"; };
 		2B5FAC092406B8B7008A285F /* Feature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature.swift; sourceTree = "<group>"; };
@@ -346,6 +354,8 @@
 				2B5FAC0024067051008A285F /* GeometryCollectionTests.swift */,
 				3547ECF9200C3C82009DA062 /* TurfTests.swift */,
 				3547ECFA200C3C82009DA062 /* Fixtures */,
+				11E726F926247D3900C1890B /* LocationCoordinate2DTests.swift */,
+				11E7270B2624840900C1890B /* RadianCoordinate2DTests.swift */,
 			);
 			path = TurfTests;
 			sourceTree = "<group>";
@@ -750,6 +760,8 @@
 			files = (
 				35B56EA020DAF88C00C4923D /* PolygonTests.swift in Sources */,
 				35B56EAC20DAF8CB00C4923D /* MultiPolygonTests.swift in Sources */,
+				11E7270D2624840900C1890B /* RadianCoordinate2DTests.swift in Sources */,
+				11E726FB26247D3900C1890B /* LocationCoordinate2DTests.swift in Sources */,
 				35B56E9820DAF82F00C4923D /* PointTests.swift in Sources */,
 				2B5FAC0224067051008A285F /* GeometryCollectionTests.swift in Sources */,
 				CE7F8165215182FF00A9D221 /* BoundingBoxTests.swift in Sources */,
@@ -795,6 +807,8 @@
 			files = (
 				35B56E9F20DAF88C00C4923D /* PolygonTests.swift in Sources */,
 				2B5FAC122406BADF008A285F /* GeoJSONTests.swift in Sources */,
+				11E7270C2624840900C1890B /* RadianCoordinate2DTests.swift in Sources */,
+				11E726FA26247D3900C1890B /* LocationCoordinate2DTests.swift in Sources */,
 				35B56EAB20DAF8CB00C4923D /* MultiPolygonTests.swift in Sources */,
 				35B56E9720DAF82F00C4923D /* PointTests.swift in Sources */,
 				2B5FAC0124067051008A285F /* GeometryCollectionTests.swift in Sources */,
@@ -840,6 +854,8 @@
 			files = (
 				35B56EA120DAF88C00C4923D /* PolygonTests.swift in Sources */,
 				35B56EAD20DAF8CB00C4923D /* MultiPolygonTests.swift in Sources */,
+				11E7270E2624840900C1890B /* RadianCoordinate2DTests.swift in Sources */,
+				11E7270326247D4000C1890B /* LocationCoordinate2DTests.swift in Sources */,
 				35B56E9920DAF82F00C4923D /* PointTests.swift in Sources */,
 				2B5FAC0324067051008A285F /* GeometryCollectionTests.swift in Sources */,
 				CE7F8166215182FF00A9D221 /* BoundingBoxTests.swift in Sources */,


### PR DESCRIPTION
Fixes #38.
New Measurement API is available from iOS 10 and allows to specify concrete units for all measurements.
Previously we expected a Double value in radians, however, it was possible for the user to pass Double value in degrees.
This PR ensures that the user will pass only values that are measured in radians.