### PR TITLE
Vendor swiftenv installation script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ language: generic
 sudo: required
 dist: trusty
 env:
-  - SWIFT_VERSION=5.0
+  - SWIFT_VERSION=5.0 SWIFTENV_ROOT="$HOME/.swiftenv" PATH="$SWIFTENV_ROOT/bin:$SWIFTENV_ROOT/shims:$PATH"
 install:
-  - eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
+  - ./scripts/install_swiftenv.sh
 script:
   - swift build

--- a/scripts/install_swiftenv.sh
+++ b/scripts/install_swiftenv.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Automatically installs swiftenv and run's swiftenv install.
+# This script was designed for usage in CI systems.
+
+git clone --depth 1 https://github.com/kylef/swiftenv.git ~/.swiftenv
+export SWIFTENV_ROOT="$HOME/.swiftenv"
+export PATH="$SWIFTENV_ROOT/bin:$SWIFTENV_ROOT/shims:$PATH"
+
+if [ -f ".swift-version" ] || [ -n "$SWIFT_VERSION" ]; then
+  swiftenv install -s
+else
+  swiftenv rehash
+fi
+


### PR DESCRIPTION
This PR copies the swiftenv installation script from https://swiftenv.fuller.li/en/latest/install.sh, since the script is stable and quite simple. It is unfortunately still necessary because the Travis image still has the Swift 4._x_ toolchain installed by default.

/cc @mapbox/navigation-ios