### PR TITLE
Add conversions between enumerations and associated values

### DIFF
--- a/Sources/Turf/Feature.swift
+++ b/Sources/Turf/Feature.swift
@@ -25,8 +25,17 @@ public struct Feature: Equatable {
      
      - parameter geometry: The geometry at which the feature is located.
      */
-    public init(geometry: Geometry?) {
+    public init(geometry: Geometry) {
         self.geometry = geometry
+    }
+    
+    /**
+     Initializes a feature defined by the given geometry-convertible instance.
+     
+     - parameter geometry: The geometry-convertible instance that bounds the feature.
+     */
+    public init(geometry: GeometryConvertible?) {
+        self.geometry = geometry?.geometry
     }
 }
 

--- a/Sources/Turf/FeatureIdentifier.swift
+++ b/Sources/Turf/FeatureIdentifier.swift
@@ -3,7 +3,7 @@ import Foundation
 /**
  A [feature identifier](https://datatracker.ietf.org/doc/html/rfc7946#section-3.2) identifies a `Feature` object.
  */
-public enum FeatureIdentifier: Equatable {
+public enum FeatureIdentifier: Hashable {
     /// A string.
     case string(_ string: String)
     

--- a/Sources/Turf/GeoJSON.swift
+++ b/Sources/Turf/GeoJSON.swift
@@ -74,6 +74,10 @@ public protocol GeoJSONObjectConvertible {
     var geoJSONObject: GeoJSONObject { get }
 }
 
+extension GeoJSONObject: GeoJSONObjectConvertible {
+    public var geoJSONObject: GeoJSONObject { return self }
+}
+
 extension Geometry: GeoJSONObjectConvertible {
     public var geoJSONObject: GeoJSONObject { return .geometry(self) }
 }

--- a/Sources/Turf/GeoJSON.swift
+++ b/Sources/Turf/GeoJSON.swift
@@ -28,6 +28,11 @@ public enum GeoJSONObject: Equatable {
      - parameter featureCollection: The GeoJSON object as a FeatureCollection object.
      */
     case featureCollection(_ featureCollection: FeatureCollection)
+    
+    /// Initializes a GeoJSON object representing the given GeoJSON object–convertible instance.
+    public init(_ object: GeoJSONObjectConvertible) {
+        self = object.geoJSONObject
+    }
 }
 
 extension GeoJSONObject: Codable {
@@ -59,4 +64,24 @@ extension GeoJSONObject: Codable {
             try container.encode(featureCollection)
         }
     }
+}
+
+/**
+ A type that can be represented as a `GeoJSONObject` instance.
+ */
+public protocol GeoJSONObjectConvertible {
+    /// The instance wrapped in a `GeoJSONObject` instance.
+    var geoJSONObject: GeoJSONObject { get }
+}
+
+extension Geometry: GeoJSONObjectConvertible {
+    public var geoJSONObject: GeoJSONObject { return .geometry(self) }
+}
+
+extension Feature: GeoJSONObjectConvertible {
+    public var geoJSONObject: GeoJSONObject { return .feature(self) }
+}
+
+extension FeatureCollection: GeoJSONObjectConvertible {
+    public var geoJSONObject: GeoJSONObject { return .featureCollection(self) }
 }

--- a/Sources/Turf/Geometry.swift
+++ b/Sources/Turf/Geometry.swift
@@ -27,6 +27,11 @@ public enum Geometry: Equatable {
     
     /// A heterogeneous collection of geometries that are related.
     case geometryCollection(_ geometry: GeometryCollection)
+    
+    /// Initializes a geometry representing the given geometry–convertible instance.
+    public init(_ geometry: GeometryConvertible) {
+        self = geometry.geometry
+    }
 }
 
 extension Geometry: Codable {
@@ -84,4 +89,44 @@ extension Geometry: Codable {
             try container.encode(geometryCollection)
         }
     }
+}
+
+/**
+ A type that can be represented as a `Geometry` instance.
+ */
+public protocol GeometryConvertible {
+    /// The instance wrapped in a `Geometry` instance.
+    var geometry: Geometry { get }
+}
+
+extension Geometry: GeometryConvertible {
+    public var geometry: Geometry { return self }
+}
+
+extension Point: GeometryConvertible {
+    public var geometry: Geometry { return .point(self) }
+}
+
+extension LineString: GeometryConvertible {
+    public var geometry: Geometry { return .lineString(self) }
+}
+
+extension Polygon: GeometryConvertible {
+    public var geometry: Geometry { return .polygon(self) }
+}
+
+extension MultiPoint: GeometryConvertible {
+    public var geometry: Geometry { return .multiPoint(self) }
+}
+
+extension MultiLineString: GeometryConvertible {
+    public var geometry: Geometry { return .multiLineString(self) }
+}
+
+extension MultiPolygon: GeometryConvertible {
+    public var geometry: Geometry { return .multiPolygon(self) }
+}
+
+extension GeometryCollection: GeometryConvertible {
+    public var geometry: Geometry { return .geometryCollection(self) }
 }

--- a/Sources/Turf/JSON.swift
+++ b/Sources/Turf/JSON.swift
@@ -5,7 +5,7 @@ import Foundation
  
  This type does not represent the `null` value in JSON. Use `Optional<JSONValue>` wherever `null` is accepted.
  */
-public enum JSONValue: Equatable {
+public enum JSONValue: Hashable {
     // case null would be redundant to Optional.none
     
     /// A string.

--- a/Tests/TurfTests/GeoJSONTests.swift
+++ b/Tests/TurfTests/GeoJSONTests.swift
@@ -23,11 +23,16 @@ class GeoJSONTests: XCTestCase {
         XCTAssertEqual(Geometry(GeometryCollection(geometries: [])),
                        .geometryCollection(GeometryCollection(geometries: [])))
         
+        XCTAssertEqual(Geometry(Geometry(Geometry(Geometry(Point(nullIsland))))), .point(.init(nullIsland)))
+        
         XCTAssertEqual(GeoJSONObject(Geometry(Point(nullIsland))), .geometry(.point(.init(nullIsland))))
         XCTAssertEqual(GeoJSONObject(Feature(geometry: nil)), .feature(.init(geometry: nil)))
         let nullGeometry: Geometry? = nil
         XCTAssertEqual(GeoJSONObject(Feature(geometry: nullGeometry)), .feature(.init(geometry: nil)))
         XCTAssertEqual(GeoJSONObject(FeatureCollection(features: [])), .featureCollection(.init(features: [])))
+        
+        XCTAssertEqual(GeoJSONObject(GeoJSONObject(GeoJSONObject(GeoJSONObject(Geometry(Point(nullIsland)))))),
+                       .geometry(.point(.init(nullIsland))))
     }
     
     func testPoint() {

--- a/Tests/TurfTests/GeoJSONTests.swift
+++ b/Tests/TurfTests/GeoJSONTests.swift
@@ -6,6 +6,29 @@ import struct Turf.Polygon
 import CoreLocation
 
 class GeoJSONTests: XCTestCase {
+    func testConversion() {
+        let nullIsland = LocationCoordinate2D(latitude: 0, longitude: 0)
+        XCTAssertEqual(Geometry(Point(nullIsland)),
+                       .point(Point(nullIsland)))
+        XCTAssertEqual(Geometry(LineString([nullIsland, nullIsland])),
+                       .lineString(LineString([nullIsland, nullIsland])))
+        XCTAssertEqual(Geometry(Polygon([[nullIsland, nullIsland, nullIsland]])),
+                       .polygon(Polygon([[nullIsland, nullIsland, nullIsland]])))
+        XCTAssertEqual(Geometry(MultiPoint([nullIsland, nullIsland, nullIsland])),
+                       .multiPoint(MultiPoint([nullIsland, nullIsland, nullIsland])))
+        XCTAssertEqual(Geometry(MultiLineString([[nullIsland, nullIsland, nullIsland]])),
+                       .multiLineString(MultiLineString([[nullIsland, nullIsland, nullIsland]])))
+        XCTAssertEqual(Geometry(MultiPolygon([[[nullIsland, nullIsland, nullIsland]]])),
+                       .multiPolygon(MultiPolygon([[[nullIsland, nullIsland, nullIsland]]])))
+        XCTAssertEqual(Geometry(GeometryCollection(geometries: [])),
+                       .geometryCollection(GeometryCollection(geometries: [])))
+        
+        XCTAssertEqual(GeoJSONObject(Geometry(Point(nullIsland))), .geometry(.point(.init(nullIsland))))
+        XCTAssertEqual(GeoJSONObject(Feature(geometry: nil)), .feature(.init(geometry: nil)))
+        let nullGeometry: Geometry? = nil
+        XCTAssertEqual(GeoJSONObject(Feature(geometry: nullGeometry)), .feature(.init(geometry: nil)))
+        XCTAssertEqual(GeoJSONObject(FeatureCollection(features: [])), .featureCollection(.init(features: [])))
+    }
     
     func testPoint() {
         let coordinate = LocationCoordinate2D(latitude: 10, longitude: 30)


### PR DESCRIPTION
Added protocol-based initializers to `Geometry` and `GeoJSONObject` that accept each case’s associated value as an initializer argument. This makes the enumerations more consistent with the `JSONValue` and `FeatureIdentifier` enumerations and simplifies some common workflows.

JSONValue and FeatureIdentifier now conform to the `Hashable` protocol. These types are likely to be used as dictionary keys or set members, and it’s pretty easy to make them hashable.

Fixes #158.

/cc @mapbox/navigation-ios @mapbox/maps-ios