### PR TITLE
Swap names of simplify and simplified

### DIFF
--- a/Sources/Turf/Geometries/LineString.swift
+++ b/Sources/Turf/Geometries/LineString.swift
@@ -261,11 +261,11 @@ extension LineString {
     /// highestQuality: Excludes distance-based preprocessing step which leads to highest quality simplification. High quality simplification runs considerably slower so consider how much precision is needed in your application.
     ///
     /// Ported from https://github.com/Turfjs/turf/blob/master/packages/turf-simplify/lib/simplify.js
-    public func simplify(tolerance: Double = 1.0, highestQuality: Bool = false) -> LineString {
+    public func simplified(tolerance: Double = 1.0, highestQuality: Bool = false) -> LineString {
         guard coordinates.count > 2 else { return LineString(coordinates) }
 
         var copy = LineString(coordinates)
-        copy.simplified(tolerance: tolerance, highestQuality: highestQuality)
+        copy.simplify(tolerance: tolerance, highestQuality: highestQuality)
         return copy
     }
 
@@ -277,7 +277,7 @@ extension LineString {
     /// highestQuality: Excludes distance-based preprocessing step which leads to highest quality simplification. High quality simplification runs considerably slower so consider how much precision is needed in your application.
     ///
     /// Ported from https://github.com/Turfjs/turf/blob/master/packages/turf-simplify/lib/simplify.js
-    public mutating func simplified(tolerance: Double = 1.0, highestQuality: Bool = false) {
+    public mutating func simplify(tolerance: Double = 1.0, highestQuality: Bool = false) {
         coordinates = Simplifier.simplify(coordinates, tolerance: tolerance, highestQuality: highestQuality)
     }
 }

--- a/Sources/Turf/Geometries/Polygon.swift
+++ b/Sources/Turf/Geometries/Polygon.swift
@@ -187,9 +187,9 @@ extension Polygon {
     /// highestQuality: Excludes distance-based preprocessing step which leads to highest quality simplification. High quality simplification runs considerably slower so consider how much precision is needed in your application.
     ///
     /// Ported from https://github.com/Turfjs/turf/blob/master/packages/turf-simplify/lib/simplify.js
-    public func simplify(tolerance: Double = 1.0, highestQuality: Bool = false) -> Polygon {
+    public func simplified(tolerance: Double = 1.0, highestQuality: Bool = false) -> Polygon {
         var copy = Polygon(coordinates)
-        copy.simplified(tolerance: tolerance, highestQuality: highestQuality)
+        copy.simplify(tolerance: tolerance, highestQuality: highestQuality)
         return copy
     }
 
@@ -201,7 +201,7 @@ extension Polygon {
     /// highestQuality: Excludes distance-based preprocessing step which leads to highest quality simplification. High quality simplification runs considerably slower so consider how much precision is needed in your application.
     ///
     /// Ported from https://github.com/Turfjs/turf/blob/master/packages/turf-simplify/lib/simplify.js
-    public mutating func simplified(tolerance: Double = 1.0, highestQuality: Bool = false) {
+    public mutating func simplify(tolerance: Double = 1.0, highestQuality: Bool = false) {
         coordinates = coordinates.map { ring in
             guard ring.count > 3 else { return ring }
             

--- a/Tests/TurfTests/TurfTests.swift
+++ b/Tests/TurfTests/TurfTests.swift
@@ -187,11 +187,11 @@ class TurfTests: XCTestCase {
                         break // nothing to simplify
                     
                     case let (.lineString(lineIn), .lineString(lineOut)):
-                        let simplified = lineIn.simplify(tolerance: tolerance, highestQuality: highQuality)
+                        let simplified = lineIn.simplified(tolerance: tolerance, highestQuality: highQuality)
                         XCTAssertEqual(lineOut.coordinates, simplified.coordinates, accuracy: 0.00001, "Fixture test failed for \(name)")
 
                     case let (.polygon(polyIn), .polygon(polyOut)):
-                        let simplified = polyIn.simplify(tolerance: tolerance, highestQuality: highQuality)
+                        let simplified = polyIn.simplified(tolerance: tolerance, highestQuality: highQuality)
                         XCTAssertEqual(polyOut.coordinates, simplified.coordinates, accuracy: 0.00001, "Fixture test failed for \(name)")
 
                     default:


### PR DESCRIPTION
Renamed `LineString.simplify(tolerance:highestQuality:)` and `Polygon.simplify(tolerance:highestQuality:)` to `LineString.simplified(tolerance:highestQuality:)` and `Polygon.simplified(tolerance:highestQuality:)`, respectively and vice versa. Mutating methods should be named in the imperative mood; nonmutating methods should be named with past participles.

/cc @macdrevx @nighthawk