### PR TITLE
Improve performance of trimmed(from:,to:)

### DIFF
--- a/Sources/Turf/Geometries/LineString.swift
+++ b/Sources/Turf/Geometries/LineString.swift
@@ -134,7 +134,7 @@ extension LineString {
                 return LineString(slice)
             }
             
-            traveled += distance(from: coordinates[i], to: coordinates[i + 1]) ?? 0.0
+            traveled += coordinates[i].distance(to: coordinates[i + 1])
         }
         
         if traveled < startDistance { return nil }


### PR DESCRIPTION
So, I found the performance of the `LineString.trimmed(from:to:)` to be unusably slow and that it's caused by this distance calculation.

Calculating the distance between coordinates `i` and `i+1` can be done with a simple/cheap `distance(to:)`, but instead the `LineString.distance(from:to:)` is used, which kills performance because it allows `from`/`to` to not be on the line and has to calculate which line coordinate is closest using `closestCoordinate(to:)`, a O(n) operation, which leaves `trimmed(from:to:)` at a terrible O(n^2).

Please let me know if I'm missing anything.