### PR TITLE
Enabling automatic test discovery on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ env:
 install:
   - ./scripts/install_swiftenv.sh
 script:
-  - swift test --enable-test-discovery
+  - swift test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ language: generic
 sudo: required
 dist: trusty
 env:
-  - SWIFT_VERSION=5.0 SWIFTENV_ROOT="$HOME/.swiftenv" PATH="$SWIFTENV_ROOT/bin:$SWIFTENV_ROOT/shims:$PATH"
+  - SWIFT_VERSION=5.4 SWIFTENV_ROOT="$HOME/.swiftenv" PATH="$SWIFTENV_ROOT/bin:$SWIFTENV_ROOT/shims:$PATH"
 install:
   - ./scripts/install_swiftenv.sh
 script:
-  - swift build
+  - swift test --enable-test-discovery

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ os:
   - linux
 language: generic
 sudo: required
-dist: trusty
+dist: xenial
 env:
   - SWIFT_VERSION=5.4 SWIFTENV_ROOT="$HOME/.swiftenv" PATH="$SWIFTENV_ROOT/bin:$SWIFTENV_ROOT/shims:$PATH"
 install:

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.4
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -28,6 +28,11 @@ let package = Package(
         .testTarget(
             name: "TurfTests",
             dependencies: ["Turf"],
-            exclude: ["Info.plist"]),
+            exclude: ["Info.plist", "Fixtures/simplify"],
+            resources: [
+                .process("Fixtures"),
+            ],
+            swiftSettings: [.define("SPM_TESTING")]
+        ),
     ]
 )

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,6 +1,0 @@
-import XCTest
-@testable import Turf
-
-XCTMain([
-    testCase(TurfTests.allTests)
-])

--- a/Tests/TurfTests/Fixture.swift
+++ b/Tests/TurfTests/Fixture.swift
@@ -2,6 +2,13 @@ import XCTest
 import Foundation
 
 class Fixture {
+    class func moduleBundle() -> Bundle {
+        #if SPM_TESTING
+        return Bundle.module
+        #else
+        return Bundle(for: self)
+        #endif
+    }
     class func stringFromFileNamed(name: String) -> String {
         guard let path = Bundle(for: self).path(forResource: name, ofType: "json") ?? Bundle(for: self).path(forResource: name, ofType: "geojson") else {
             XCTAssert(false, "Fixture \(name) not found.")
@@ -16,7 +23,7 @@ class Fixture {
     }
     
     class func geojsonData(from name: String) throws -> Data? {
-        guard let path = Bundle(for: self).path(forResource: name, ofType: "geojson") else {
+        guard let path = moduleBundle().path(forResource: name, ofType: "geojson") else {
             XCTAssert(false, "Fixture \(name) not found.")
             return nil
         }
@@ -25,7 +32,24 @@ class Fixture {
     }
     
     class func JSONFromFileNamed(name: String) -> [String: Any] {
-        guard let path = Bundle(for: self).path(forResource: name, ofType: "json") ?? Bundle(for: self).path(forResource: name, ofType: "geojson") else {
+        guard let path = moduleBundle().path(forResource: name, ofType: "json") ?? Bundle(for: self).path(forResource: name, ofType: "geojson") else {
+            XCTAssert(false, "Fixture \(name) not found.")
+            return [:]
+        }
+        guard let data = NSData(contentsOfFile: path) else {
+            XCTAssert(false, "No data found at \(path).")
+            return [:]
+        }
+        do {
+            return try JSONSerialization.jsonObject(with: data as Data, options: []) as! [String: AnyObject]
+        } catch {
+            XCTAssert(false, "Unable to decode JSON fixture at \(path): \(error).")
+            return [:]
+        }
+    }
+    
+    class func JSONFromGEOJSONFileNamed(name: String) -> [String: Any] {
+        guard let path = moduleBundle().path(forResource: name, ofType: "geojson") ?? Bundle(for: self).path(forResource: name, ofType: "geojson") else {
             XCTAssert(false, "Fixture \(name) not found.")
             return [:]
         }

--- a/Tests/TurfTests/GeoJSONTests.swift
+++ b/Tests/TurfTests/GeoJSONTests.swift
@@ -3,7 +3,6 @@ import Turf
 #if os(macOS)
 import struct Turf.Polygon
 #endif
-import CoreLocation
 
 class GeoJSONTests: XCTestCase {
     func testConversion() {

--- a/Tests/TurfTests/LineStringTests.swift
+++ b/Tests/TurfTests/LineStringTests.swift
@@ -245,7 +245,7 @@ class LineStringTests: XCTestCase {
     func testCoordinateFromStart() {
         // Ported from https://github.com/Turfjs/turf/blob/142e137ce0c758e2825a260ab32b24db0aa19439/packages/turf-along/test.js
         
-        let json = Fixture.JSONFromFileNamed(name: "dc-line")
+        let json = Fixture.JSONFromGEOJSONFileNamed(name: "dc-line")
         let line = ((json["geometry"] as! [String: Any])["coordinates"] as! [[Double]]).map { LocationCoordinate2D(latitude: $0[0], longitude: $0[1]) }
         
         let pointsAlong = [

--- a/Tests/TurfTests/LineStringTests.swift
+++ b/Tests/TurfTests/LineStringTests.swift
@@ -371,7 +371,7 @@ class LineStringTests: XCTestCase {
             [122.82714843749999, 37.37015718405753]
           ]
         let line1 = LineString(coordinates.map{
-            CLLocationCoordinate2D(latitude: $0.last!, longitude: $0.first!)
+            LocationCoordinate2D(latitude: $0.last!, longitude: $0.first!)
         })
         
         var startDistance = 804672.0

--- a/Tests/TurfTests/TurfTests.swift
+++ b/Tests/TurfTests/TurfTests.swift
@@ -47,8 +47,8 @@ class TurfTests: XCTestCase {
         XCTAssertEqual(a, coord1)
     }
     
-    func testCLLocationDegrees() {
-        let degree: CLLocationDegrees = 100
+    func testLocationDegrees() {
+        let degree: LocationDegrees = 100
         let a = degree.toRadians()
         XCTAssertEqual(a, 2, accuracy: 1)
         
@@ -225,7 +225,7 @@ extension GeoJSONObject {
     }
 }
 
-func XCTAssertEqual(_ expected: [[LocationCoordinate2D]], _ actual: [[LocationCoordinate2D]], accuracy: CLLocationDegrees, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) {
+func XCTAssertEqual(_ expected: [[LocationCoordinate2D]], _ actual: [[LocationCoordinate2D]], accuracy: LocationDegrees, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) {
     XCTAssertEqual(expected.count, actual.count, message(), file: file, line: line)
     guard expected.count == actual.count else { return }
     
@@ -234,7 +234,7 @@ func XCTAssertEqual(_ expected: [[LocationCoordinate2D]], _ actual: [[LocationCo
     }
 }
 
-func XCTAssertEqual(_ expected: [LocationCoordinate2D], _ actual: [LocationCoordinate2D], accuracy: CLLocationDegrees, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) {
+func XCTAssertEqual(_ expected: [LocationCoordinate2D], _ actual: [LocationCoordinate2D], accuracy: LocationDegrees, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) {
     XCTAssertEqual(expected.count, actual.count, message(), file: file, line: line)
     guard expected.count == actual.count else { return }
     

--- a/Tests/TurfTests/TurfTests.swift
+++ b/Tests/TurfTests/TurfTests.swift
@@ -58,7 +58,7 @@ class TurfTests: XCTestCase {
     }
     
     func testPolygonArea() {
-        let json = Fixture.JSONFromFileNamed(name: "polygon")
+        let json = Fixture.JSONFromGEOJSONFileNamed(name: "polygon")
         let geometry = json["geometry"] as! [String: Any]
         let geoJSONCoordinates = geometry["coordinates"] as! [[[Double]]]
         let coordinates = geoJSONCoordinates.map {

--- a/Tests/TurfTests/WKTTests.swift
+++ b/Tests/TurfTests/WKTTests.swift
@@ -222,7 +222,7 @@ MULTIPOLYGON(((123.53 -12.12,10.0 20.0),(-11.12 13.14)),((-15.16 -17.18))))
         XCTAssertNotNil(geometryCollection)
         XCTAssertEqual(geometryCollection?.geometries.count, 6)
         
-        assertGeometryTypesEqual(geometryCollection?.geometries[0], .point(Point(.init())))
+        assertGeometryTypesEqual(geometryCollection?.geometries[0], .point(Point(LocationCoordinate2D(latitude: 0, longitude: 0))))
         assertGeometryTypesEqual(geometryCollection?.geometries[1], .multiPoint(MultiPoint([])))
         assertGeometryTypesEqual(geometryCollection?.geometries[2], .lineString(LineString([])))
         assertGeometryTypesEqual(geometryCollection?.geometries[3], .multiLineString(MultiLineString([])))

--- a/Tests/TurfTests/WKTTests.swift
+++ b/Tests/TurfTests/WKTTests.swift
@@ -201,7 +201,7 @@ class WKTTests: XCTestCase {
         case .none:
             XCTAssertNil(rhs)
             return
-        @unknown default:
+        case .some(_):
             XCTFail("Unknown geometry type coded.")
         }
     }

--- a/Turf.xcodeproj/project.pbxproj
+++ b/Turf.xcodeproj/project.pbxproj
@@ -103,7 +103,6 @@
 		3547ECFC200C3C82009DA062 /* polygon.geojson */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = polygon.geojson; sourceTree = "<group>"; };
 		3547ECFD200C3C82009DA062 /* Fixture.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Fixture.swift; sourceTree = "<group>"; };
 		3547ECFE200C3C82009DA062 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		3547ED09200C3C8A009DA062 /* LinuxMain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinuxMain.swift; sourceTree = "<group>"; };
 		35650AF01F150DC500B5C158 /* Turf.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Turf.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		35650AF91F150DC500B5C158 /* TurfTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TurfTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3573EA6C215A393F009899D7 /* GeoJSONTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeoJSONTests.swift; sourceTree = "<group>"; };
@@ -272,7 +271,6 @@
 		35650AFD1F150DC500B5C158 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				3547ED09200C3C8A009DA062 /* LinuxMain.swift */,
 				3547ECF8200C3C82009DA062 /* TurfTests */,
 			);
 			path = Tests;


### PR DESCRIPTION
PR updates swift version used on Travis CI linux job which enables automatic test discovery on Linux platform. Unit tests and SPM target corrected with found errors. 
Had to update Linux distributive from `Trusty` to `Xenial` since Ubuntu 14.04 does not come with Swift 5.4 support, and minimal supported version is Ubuntu 16.04 (as found [here](https://www.swift.org/download/)) which is represented with `Xenial` dist on [Travis](https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment).