### PR TITLE
Support visionOS target

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,23 @@ jobs:
       - run:
           name: "Test"
           command: swift test
+  test_simulator:
+    parameters:
+      destination:
+        type: string
+    macos:
+      xcode: 15.2.0
+    resource_class: macos.m1.medium.gen1
+    steps:
+      - checkout
+      - run:
+          name: "Test << parameters.destination >>"
+          command: |
+            xcodebuild test \
+              -scheme Turf \
+              -destination "<< parameters.destination >>" \
+              -derivedDataPath build
+
   build_for_library_evolution:
     macos:
       xcode: 15.1.0
@@ -47,4 +64,10 @@ workflows:
       - build_and_test_macos:
           matrix:
             parameters:
-              xcode_version: [13.4.1, 14.3.1, 15.1.0]
+              xcode_version: [14.3.1, 15.1.0]
+      - test_simulator:
+          matrix:
+            parameters:
+              destination:
+                - "platform=visionOS Simulator,OS=1.0,name=Apple Vision Pro"
+                - "platform=iOS Simulator,OS=17.2,name=iPhone 15"

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "Turf",
     platforms: [
-        .macOS(.v10_13), .iOS(.v11), .watchOS(.v4), .tvOS(.v11),
+        .macOS(.v10_13), .iOS(.v11), .watchOS(.v4), .tvOS(.v11), .custom("visionOS", versionString: "1.0")
     ],
     products: [
         .library(

--- a/README.md
+++ b/README.md
@@ -14,12 +14,13 @@ A [spatial analysis](http://en.wikipedia.org/wiki/Spatial_analysis) library writ
 
 ## Requirements
 
-Turf requires Xcode 13.0 or above and supports the following minimum deployment targets:
+Turf requires Xcode 14.1 or above and supports the following minimum deployment targets:
 
 * iOS 11.0 and above
 * macOS 10.13 (High Sierra) and above
 * tvOS 11.0 and above
 * watchOS 4.0 and above
+* visionOS 1.0 and above
 
 Alternatively, you can incorporate Turf into a command line tool without Xcode on any platform that [Swift](https://swift.org/download/) supports, including Linux.
 

--- a/Turf.podspec
+++ b/Turf.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.name = "Turf"
   s.version = "2.7.1"
   s.summary = "Simple spatial analysis."
-  s.description = "A spatial analysis library written in Swift for native iOS, macOS, tvOS, watchOS, and Linux applications, ported from Turf.js."
+  s.description = "A spatial analysis library written in Swift for native iOS, macOS, tvOS, watchOS, visionOS, and Linux applications, ported from Turf.js."
 
   s.homepage = "https://github.com/mapbox/turf-swift"
 
@@ -24,6 +24,9 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = "10.13"
   s.tvos.deployment_target = "11.0"
   s.watchos.deployment_target = "4.0"
+  # CocoaPods doesn't support releasing of visionOS pods yet, need to wait for v1.15.0 release of CocoaPods
+  # with this fix https://github.com/CocoaPods/CocoaPods/pull/12159.
+  # s.visionos.deployment_target = "1.0"
 
   # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
@@ -40,6 +43,6 @@ Pod::Spec.new do |s|
 
   s.frameworks = 'CoreLocation'
 
-  s.swift_version = "5.5"
+  s.swift_version = "5.7"
 
 end

--- a/Turf.xcodeproj/project.pbxproj
+++ b/Turf.xcodeproj/project.pbxproj
@@ -612,6 +612,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.turf;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator xros xrsimulator";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
@@ -632,6 +633,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.turf;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator xros xrsimulator";
 			};
 			name = Release;
 		};
@@ -644,6 +646,9 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.TurfTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator xros xrsimulator";
+				SUPPORTS_MACCATALYST = YES;
+				TARGETED_DEVICE_FAMILY = 2;
 			};
 			name = Debug;
 		};
@@ -656,6 +661,9 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.TurfTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator xros xrsimulator";
+				SUPPORTS_MACCATALYST = YES;
+				TARGETED_DEVICE_FAMILY = 2;
 			};
 			name = Release;
 		};

--- a/Turf.xcodeproj/project.pbxproj
+++ b/Turf.xcodeproj/project.pbxproj
@@ -647,8 +647,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.TurfTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator xros xrsimulator";
-				SUPPORTS_MACCATALYST = YES;
-				TARGETED_DEVICE_FAMILY = 2;
 			};
 			name = Debug;
 		};
@@ -662,8 +660,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.TurfTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator xros xrsimulator";
-				SUPPORTS_MACCATALYST = YES;
-				TARGETED_DEVICE_FAMILY = 2;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
This PR supports visionOS target. 

It also bumps the **minimal xcode version to 14.1**. This is required to use `.custom("visionOS", versionString: "1.0")` in spm, which is supported starting from swift 5.6. However, I decided it's safe to bump the minimal swift version to 5.7, as Xcode 14.1 is the minimal supported version for AppStore distribution.

Also, added CI test runs on iOS and visionOS simulators.