### PR TITLE
Fix github file prefix

### DIFF
--- a/scripts/document.sh
+++ b/scripts/document.sh
@@ -30,7 +30,7 @@ jazzy \
     --config docs/jazzy.yml \
     --sdk macosx \
     --module-version ${SHORT_VERSION} \
-    --github-file-prefix "https://github.com/mapbox/mapbox-directions-swift/tree/${BRANCH}" \
+    --github-file-prefix "https://github.com/mapbox/turf-swift/tree/${BRANCH}" \
     --readme README.md \
     --root-url "https://mapbox.github.io/turf-swift/${RELEASE_VERSION}/" \
     --output ${OUTPUT} \


### PR DESCRIPTION
Fix github links in the Jazzy docs to point turf repo instead of directions-swift