### PR TITLE
Add convenience accessors to enum values

### DIFF
--- a/Sources/Turf/FeatureIdentifier.swift
+++ b/Sources/Turf/FeatureIdentifier.swift
@@ -58,6 +58,24 @@ extension FeatureIdentifier: RawRepresentable {
     }
 }
 
+extension FeatureIdentifier {
+    /// A string.
+    public var string: String? {
+        if case let .string(value) = self {
+            return value
+        }
+        return nil
+    }
+    
+    /// A floating-point number.
+    public var number: Double? {
+        if case let .number(value) = self {
+            return value
+        }
+        return nil
+    }
+}
+
 extension FeatureIdentifier: ExpressibleByStringLiteral {
     public init(stringLiteral value: StringLiteralType) {
         self = .init(value)

--- a/Sources/Turf/GeoJSON.swift
+++ b/Sources/Turf/GeoJSON.swift
@@ -36,6 +36,32 @@ public enum GeoJSONObject: Equatable, Sendable {
     }
 }
 
+extension GeoJSONObject {
+    /// A geometry object.
+    public var geometry: Geometry? {
+        if case let .geometry(geometry) = self {
+            return geometry
+        }
+        return nil
+    }
+    
+    /// A feature object.
+    public var feature: Feature? {
+        if case let .feature(feature) = self {
+            return feature
+        }
+        return nil
+    }
+    
+    /// A feature collection object.
+    public var featureCollection: FeatureCollection? {
+        if case let .featureCollection(featureCollection) = self {
+            return featureCollection
+        }
+        return nil
+    }
+}
+
 extension GeoJSONObject: Codable {
     private enum CodingKeys: String, CodingKey {
         case kind = "type"

--- a/Sources/Turf/Geometry.swift
+++ b/Sources/Turf/Geometry.swift
@@ -91,6 +91,78 @@ extension Geometry: Codable {
     }
 }
 
+extension Geometry {
+    /// A single position.
+    public var point: Point? {
+        if case let .point(point) = self {
+            return point
+        } else {
+            return nil
+        }
+
+    }
+
+    /// A collection of two or more positions, each position connected to the next position linearly.
+    public var lineString: LineString? {
+        if case let .lineString(lineString) = self {
+            return lineString
+        } else {
+            return nil
+        }
+
+    }
+
+    /// Conceptually, a collection of `Ring`s that form a single connected geometry.
+    public var polygon: Polygon? {
+        if case let .polygon(polygon) = self {
+            return polygon
+        } else {
+            return nil
+        }
+
+    }
+
+    /// A collection of positions that are disconnected but related.
+    public var multiPoint: MultiPoint? {
+        if case let .multiPoint(multiPoint) = self {
+            return multiPoint
+        } else {
+            return nil
+        }
+
+    }
+
+    /// A collection of `LineString` geometries that are disconnected but related.
+    public var multiLineString: MultiLineString? {
+        if case let .multiLineString(multiLineString) = self {
+            return multiLineString
+        } else {
+            return nil
+        }
+
+    }
+
+    /// A collection of `Polygon` geometries that are disconnected but related.
+    public var multiPolygon: MultiPolygon? {
+        if case let .multiPolygon(multiPolygon) = self {
+            return multiPolygon
+        } else {
+            return nil
+        }
+
+    }
+
+    /// A heterogeneous collection of geometries that are related.
+    public var geometryCollection: GeometryCollection? {
+        if case let .geometryCollection(geometryCollection) = self {
+            return geometryCollection
+        } else {
+            return nil
+        }
+
+    }
+}
+
 /**
  A type that can be represented as a `Geometry` instance.
  */

--- a/Sources/Turf/JSON.swift
+++ b/Sources/Turf/JSON.swift
@@ -62,6 +62,48 @@ public enum JSONValue: Hashable, Sendable {
     }
 }
 
+extension JSONValue {
+    /// A string value, if the JSON value represents a string.
+    public var string: String? {
+        if case let .string(value) = self {
+            return value
+        }
+        return nil
+    }
+    
+    /// A floating-point number value, if the JSON value represents a number.
+    public var number: Double? {
+        if case let .number(value) = self {
+            return value
+        }
+        return nil
+    }
+    
+    /// A Boolean value, if the JSON value represents a Boolean.
+    public var boolean: Bool? {
+        if case let .boolean(value) = self {
+            return value
+        }
+        return nil
+    }
+    
+    /// An array of JSON values, if the JSON value represents an array.
+    public var array: JSONArray? {
+        if case let .array(value) = self {
+            return value
+        }
+        return nil
+    }
+    
+    /// An object containing JSON values keyed by strings, if the JSON value represents an object.
+    public var object: JSONObject? {
+        if case let .object(value) = self {
+            return value
+        }
+        return nil
+    }
+}
+
 extension JSONValue: RawRepresentable {
     public typealias RawValue = Any
     

--- a/Tests/TurfTests/FeatureIdentifier.swift
+++ b/Tests/TurfTests/FeatureIdentifier.swift
@@ -1,0 +1,12 @@
+import Turf
+import XCTest
+
+final class FeatureIdentifierTests: XCTestCase {
+    func testConvenienceAccessors() {
+        XCTAssertEqual(FeatureIdentifier("foo").string, "foo")
+        XCTAssertEqual(FeatureIdentifier("foo").number, nil)
+
+        XCTAssertEqual(FeatureIdentifier(3.14).string, nil)
+        XCTAssertEqual(FeatureIdentifier(3.14).number, 3.14)
+    }
+}

--- a/Tests/TurfTests/GeoJSONTests.swift
+++ b/Tests/TurfTests/GeoJSONTests.swift
@@ -270,4 +270,18 @@ class GeoJSONTests: XCTestCase {
         try testForeignMemberCoding(in: .feature(.init(geometry: nil)))
         try testForeignMemberCoding(in: .featureCollection(.init(features: [])))
     }
+
+    func testConvenienceAccessors() {
+        let point = Point(LocationCoordinate2D(latitude: 0, longitude: 1))
+        XCTAssertEqual(GeoJSONObject.geometry(point.geometry).geometry, point.geometry)
+        XCTAssertEqual(GeoJSONObject.geometry(point.geometry).feature, nil)
+     
+        let feature = Feature(geometry: point)
+        XCTAssertEqual(GeoJSONObject.feature(feature).feature, feature)
+        XCTAssertEqual(GeoJSONObject.feature(feature).geometry, nil)
+        
+        let featureCollection = FeatureCollection(features: [feature])
+        XCTAssertEqual(GeoJSONObject.featureCollection(featureCollection).featureCollection, featureCollection)   
+        XCTAssertEqual(GeoJSONObject.featureCollection(featureCollection).geometry, nil)
+    }
 }

--- a/Tests/TurfTests/GeometryTests.swift
+++ b/Tests/TurfTests/GeometryTests.swift
@@ -1,0 +1,37 @@
+import Turf
+import XCTest
+
+final class GeometryTests: XCTestCase {
+    func testConvenienceAccessors() {
+        let point = Point(LocationCoordinate2D(latitude: 1, longitude: 2))
+        XCTAssertEqual(Geometry.point(point).point, point)
+        XCTAssertEqual(Geometry.point(point).lineString, nil)
+
+        let lineString = LineString([LocationCoordinate2D(latitude: 1, longitude: 2)])
+        XCTAssertEqual(Geometry.lineString(lineString).lineString, lineString)
+        XCTAssertEqual(Geometry.lineString(lineString).point, nil)
+
+        let polygon = Polygon([[LocationCoordinate2D(latitude: 1, longitude: 2)]])
+        XCTAssertEqual(Geometry.polygon(polygon).polygon, polygon)
+        XCTAssertEqual(Geometry.polygon(polygon).point, nil)
+
+
+        let multiPoint = MultiPoint([LocationCoordinate2D(latitude: 1, longitude: 2)])
+        XCTAssertEqual(Geometry.multiPoint(multiPoint).multiPoint, multiPoint)
+        XCTAssertEqual(Geometry.multiPoint(multiPoint).point, nil)
+
+        let multiLineString = MultiLineString([[LocationCoordinate2D(latitude: 1, longitude: 2)]])
+        XCTAssertEqual(Geometry.multiLineString(multiLineString).multiLineString, multiLineString)
+        XCTAssertEqual(Geometry.multiLineString(multiLineString).point, nil)
+
+        let multiPolygon = MultiPolygon([[[LocationCoordinate2D(latitude: 1, longitude: 2)]]])
+        XCTAssertEqual(Geometry.multiPolygon(multiPolygon).multiPolygon, multiPolygon)
+        XCTAssertEqual(Geometry.multiPolygon(multiPolygon).point, nil)
+
+        let geometryCollection = GeometryCollection(geometries: [
+            Geometry(point), Geometry(lineString)
+        ])
+        XCTAssertEqual(Geometry.geometryCollection(geometryCollection).geometryCollection, geometryCollection)
+        XCTAssertEqual(Geometry.geometryCollection(geometryCollection).point, nil)
+    }
+}

--- a/Tests/TurfTests/JSONTests.swift
+++ b/Tests/TurfTests/JSONTests.swift
@@ -258,4 +258,48 @@ class JSONTests: XCTestCase {
         XCTAssertNotNil(decodedValue)
         XCTAssertEqual(.array([.number(0), .number(1), .boolean(true), .boolean(false)]), decodedValue)
     }
+    
+    func testConvenienceAccessors() {
+        XCTAssertEqual(JSONValue.string("Jason").string, "Jason")
+        XCTAssertEqual(JSONValue.string("Jason").number, nil)
+
+        XCTAssertEqual(JSONValue.number(42).number, 42)
+        XCTAssertEqual(JSONValue.number(42).string, nil)
+
+        XCTAssertEqual(JSONValue.boolean(true).boolean, true)
+        XCTAssertEqual(JSONValue.boolean(true).string, nil)
+
+        XCTAssertEqual(JSONValue.array(["Jason", 42, 3.1415, false, true, nil, [], [:]]).array, ["Jason", 42, 3.1415, false, true, nil, [], [:]])
+        XCTAssertEqual(JSONValue.array(["Jason", 42, 3.1415, false, true, nil, [], [:]]).string, nil)
+
+        XCTAssertEqual(JSONValue.object([
+            "string": "Jason",
+            "integer": 42,
+            "float": 3.1415,
+            "false": false,
+            "true": true,
+            "nil": nil,
+            "array": [],
+            "dictionary": [:],
+        ]).object, [
+            "string": "Jason",
+            "integer": 42,
+            "float": 3.1415,
+            "false": false,
+            "true": true,
+            "nil": nil,
+            "array": [],
+            "dictionary": [:],
+        ])
+        XCTAssertEqual(JSONValue.object([
+            "string": "Jason",
+            "integer": 42,
+            "float": 3.1415,
+            "false": false,
+            "true": true,
+            "nil": nil,
+            "array": [],
+            "dictionary": [:],
+        ]).string, nil)
+    }
 }


### PR DESCRIPTION
This PR adds several extensions that allow enum value to be easily red and chained.

For example,
```swift
aFeature.geometry.point?.map(\.foo)
```

```swift
if let fooString = aFeature.properties.object?["foo"].string {
}
```

Doing the same with the `if let .case(foo) = bar` construction is usually cumbersome and doesn't support chaining.